### PR TITLE
revert platform tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   static-analysis:
     strategy:
       matrix:
-        task: ["lint", "fmt", "type-check", "python-build", "docker --check"]
+        task: ["lint", "fmt", "type-check", "python-build", "docker"]
       fail-fast: false
     runs-on: ubuntu-latest
 

--- a/great_expectations_cloud/agent/Dockerfile
+++ b/great_expectations_cloud/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim
+FROM --platform=linux/amd64 python:3.10.12-slim
 WORKDIR /app/
 
 RUN mkdir -p great_expectations_cloud/agent

--- a/tasks.py
+++ b/tasks.py
@@ -49,6 +49,8 @@ def docker(ctx: Context, check: bool = False, tag: str = "greatexpectations/agen
             "hadolint",
             "--failure-threshold",
             "warning",
+            "--ignore",
+            "DL3029", # Revisit support for arm platform builds https://github.com/hadolint/hadolint/wiki/DL3029
             "-",
             "<",
             DOCKERFILE_PATH,


### PR DESCRIPTION
not trivial fix to add support for arm64

I removed platform tag in previous [PR]( https://github.com/great-expectations/cloud/pull/18/files#diff-06925c091c7ca7abfba230be53583ab49f0a56b5869b8e708681a8990d3bd3e6L1), which broke docker builds on apple silicon.

This reverts the change, but also reverts us back to emulating the agent on apple silicon.