### PR TITLE
[MAINTENANCE] Make `great_expectations` dependency unbounded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.4dev"
+version = "0.0.3dev1"
 description = "Great Expectations Cloud"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-great-expectations = "*" # Needs to be ^0.17.19 but keeping unbounded to deal with dependency resolver conflicts 
+great-expectations = "*" # Needs to be ^0.17.19 but keeping unbounded to deal with dependency resolver conflicts
 pydantic = "<3"
 pika = "^1.3.1"
 snowflake-sqlalchemy = ">=1.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.3dev"
+version = "0.0.4dev"
 description = "Great Expectations Cloud"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-great-expectations = "^0.17.19"
+great-expectations = "*" # Needs to be ^0.17.19 but keeping unbounded to deal with dependency resolver conflicts 
 pydantic = "<3"
 pika = "^1.3.1"
 snowflake-sqlalchemy = ">=1.5.0"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,7 +2,8 @@ import pathlib
 from typing import Final
 
 import pytest
-import tomli
+
+# import tomli
 from packaging.version import Version
 
 PROJECT_ROOT: Final = pathlib.Path(__file__).parent.parent
@@ -11,11 +12,13 @@ PYPROJECT_TOML: Final = PROJECT_ROOT / "pyproject.toml"
 
 @pytest.fixture
 def min_gx_version() -> Version:
-    pyproject_dict = tomli.loads(PYPROJECT_TOML.read_text())
-    gx_version: str = pyproject_dict["tool"]["poetry"]["dependencies"][
-        "great-expectations"
-    ].replace("^", "")
-    return Version(gx_version)
+    # TODO: add this back once gx is pinned again
+    # pyproject_dict = tomli.loads(PYPROJECT_TOML.read_text())
+    # gx_version: str = pyproject_dict["tool"]["poetry"]["dependencies"][
+    #     "great-expectations"
+    # ].replace("^", "")
+    # return Version(gx_version)
+    return Version("0.17.19")
 
 
 def test_great_expectations_is_installed(min_gx_version):


### PR DESCRIPTION
Due to dependency resolver issues, we should accept ANY version of GX (although >=17 is actually what is required). We can resolve the versioning issues in OSS later on