### PR TITLE
Allow configuring logging from json file

### DIFF
--- a/great_expectations_cloud/agent/cli.py
+++ b/great_expectations_cloud/agent/cli.py
@@ -30,7 +30,7 @@ def _parse_args() -> Arguments:
     )
     parser.add_argument(
         "--log-cfg-file",
-        help="Path to a logging configuration json file.",
+        help="Path to a logging configuration json file. Supercedes --log-level.",
         type=pathlib.Path,
     )
     args = parser.parse_args()

--- a/great_expectations_cloud/agent/cli.py
+++ b/great_expectations_cloud/agent/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import dataclasses as dc
 import logging
+import pathlib
 
 from great_expectations_cloud.logging_cfg import LogLevel, configure_logger
 
@@ -12,6 +13,7 @@ LOGGER = logging.getLogger(__name__)
 @dc.dataclass(frozen=True)
 class Arguments:
     log_level: LogLevel
+    log_cfg_file: pathlib.Path | None
 
 
 def _parse_args() -> Arguments:
@@ -26,15 +28,24 @@ def _parse_args() -> Arguments:
         default="WARNING",
         type=LogLevel,
     )
+    parser.add_argument(
+        "--log-cfg-file",
+        help="Path to a logging configuration json file.",
+        type=pathlib.Path,
+    )
     args = parser.parse_args()
     return Arguments(
         log_level=args.log_level,
+        log_cfg_file=args.log_cfg_file,
     )
 
 
 def main() -> None:
     args: Arguments = _parse_args()
-    configure_logger(args.log_level)
+    configure_logger(
+        log_level=args.log_level,
+        log_cfg_file=args.log_cfg_file,
+    )
 
     # lazy import to ensure our cli is fast and responsive
     from great_expectations_cloud.agent import run_agent

--- a/great_expectations_cloud/logging_cfg.py
+++ b/great_expectations_cloud/logging_cfg.py
@@ -46,6 +46,8 @@ def configure_logger(
     https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
     """
     if log_cfg_file:
+        if not log_cfg_file.exists():
+            raise FileNotFoundError(f"Logging config file not found: {log_cfg_file.absolute()}")
         dict_config = json.loads(log_cfg_file.read_text())
         logging.config.dictConfig(dict_config)
         LOGGER.info(f"Configured logging from file {log_cfg_file}")

--- a/great_expectations_cloud/logging_cfg.py
+++ b/great_expectations_cloud/logging_cfg.py
@@ -35,9 +35,7 @@ class LogLevel(str, enum.Enum):
         return logging.getLevelName(self)
 
 
-def configure_logger(
-    log_level: LogLevel, log_cfg_file: pathlib.Path | None, **logger_config_kwargs
-) -> None:
+def configure_logger(log_level: LogLevel, log_cfg_file: pathlib.Path | None) -> None:
     """
     Configure the root logger for the application.
     If a log configuration file is provided, other arguments are ignored.
@@ -52,5 +50,5 @@ def configure_logger(
         logging.config.dictConfig(dict_config)
         LOGGER.info(f"Configured logging from file {log_cfg_file}")
     else:
-        logging.basicConfig(level=log_level.numeric_level, **logger_config_kwargs)
+        logging.basicConfig(level=log_level.numeric_level)
         LOGGER.info(f"Configured logging at level {log_level}")

--- a/great_expectations_cloud/logging_cfg.py
+++ b/great_expectations_cloud/logging_cfg.py
@@ -42,6 +42,8 @@ def configure_logger(log_level: LogLevel, log_cfg_file: pathlib.Path | None) -> 
 
     See the documentation for the logging.config.dictConfig method for details.
     https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+
+    Note: this method should only be called once in the lifecycle of the application.
     """
     if log_cfg_file:
         if not log_cfg_file.exists():

--- a/great_expectations_cloud/logging_cfg.py
+++ b/great_expectations_cloud/logging_cfg.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import enum
+import json
 import logging
+import logging.config
+import pathlib
 
 from typing_extensions import override
 
@@ -32,6 +35,20 @@ class LogLevel(str, enum.Enum):
         return logging.getLevelName(self)
 
 
-def configure_logger(log_level: LogLevel, **logger_config_kwargs) -> None:
-    logging.basicConfig(level=log_level.numeric_level, **logger_config_kwargs)
-    LOGGER.info(f"Configured logging at level {log_level}")
+def configure_logger(
+    log_level: LogLevel, log_cfg_file: pathlib.Path | None, **logger_config_kwargs
+) -> None:
+    """
+    Configure the root logger for the application.
+    If a log configuration file is provided, other arguments are ignored.
+
+    See the documentation for the logging.config.dictConfig method for details.
+    https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+    """
+    if log_cfg_file:
+        dict_config = json.loads(log_cfg_file.read_text())
+        logging.config.dictConfig(dict_config)
+        LOGGER.info(f"Configured logging from file {log_cfg_file}")
+    else:
+        logging.basicConfig(level=log_level.numeric_level, **logger_config_kwargs)
+        LOGGER.info(f"Configured logging at level {log_level}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.3dev4"
+version = "0.0.3dev5"
 description = "Great Expectations Cloud"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -15,7 +15,7 @@ import pytest
 def test_command_retuns_zero_exit_code(cmd: str):
     cli_cmds = ["gx-agent", cmd]
     print(f"Testing command:\n  {' '.join(cli_cmds)}\n")
-    cmplt_process = subprocess.run(cli_cmds, check=False, timeout=4.0)
+    cmplt_process = subprocess.run(cli_cmds, check=False, timeout=5.0)
     print(cmplt_process.stdout)
     assert cmplt_process.returncode == 0
 

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -15,7 +15,7 @@ import pytest
 def test_command_retuns_zero_exit_code(cmd: str):
     cli_cmds = ["gx-agent", cmd]
     print(f"Testing command:\n  {' '.join(cli_cmds)}\n")
-    cmplt_process = subprocess.run(cli_cmds, check=False, timeout=5.0)
+    cmplt_process = subprocess.run(cli_cmds, check=False, timeout=6.0)
     print(cmplt_process.stdout)
     assert cmplt_process.returncode == 0
 

--- a/tests/test_logging_cfg.py
+++ b/tests/test_logging_cfg.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from great_expectations_cloud.logging_cfg import LogLevel
+
+
+class TestLogLevel:
+    @pytest.mark.parametrize(
+        "log_level",
+        [
+            "DEBUG",
+            "debug",
+            "INFO",
+            "info",
+            "WARNING",
+            "warning",
+            "ERROR",
+            "error",
+            "CRITICAL",
+            "critical",
+        ],
+    )
+    def test_valid_values(self, log_level: str):
+        enum_instance = LogLevel(log_level)  # should not raise an error
+        assert enum_instance == log_level.upper()
+
+    def test_invalid_values(self):
+        with pytest.raises(ValueError):
+            LogLevel("not_a_valid_log_level")
+
+    def test_numeric_level(self):
+        assert LogLevel.DEBUG.numeric_level == 10
+        assert LogLevel.INFO.numeric_level == 20
+        assert LogLevel.WARNING.numeric_level == 30
+        assert LogLevel.ERROR.numeric_level == 40
+        assert LogLevel.CRITICAL.numeric_level == 50
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
Allow for more advanced configuration of the agent logger by passing the path to a json config file.

https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema

```console
$ gx-agent --help                                               
usage: gx-agent [-h] [--log-level LOG_LEVEL] [--log-cfg-file LOG_CFG_FILE]

optional arguments:
  -h, --help            show this help message and exit
  --log-level LOG_LEVEL
                        Level of logging to use. Defaults to WARNING.
  --log-cfg-file LOG_CFG_FILE
                        Path to a logging configuration json file. Supercedes --log-level.
```