### PR TITLE
Release 0.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 name = "great_expectations_cloud"
 version = "0.0.3"
 description = "Great Expectations Cloud"
+repository = "https://github.com/great-expectations/cloud"
+homepage = "https://greatexpectations.io"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.3.dev8"
+version = "0.0.3"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 name = "great_expectations_cloud"
 version = "0.0.3"
 description = "Great Expectations Cloud"
-repository = "https://github.com/great-expectations/cloud"
-homepage = "https://greatexpectations.io"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"
 homepage = "https://greatexpectations.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,15 @@ homepage = "https://greatexpectations.io"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 readme = "README.md"
 license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/tasks.py
+++ b/tasks.py
@@ -141,13 +141,18 @@ def _get_latest_version() -> Version:
 
 def _bump_version(version_: Version, pre_release: bool) -> Version:
     if not pre_release:
-        # standard release
-        new_version = Version(f"{version_.major}.{version_.minor}.{version_.micro + 1}")
+        # standard release - remove the dev component if it exists
+        if version_.dev:
+            new_version = Version(f"{version_.major}.{version_.minor}.{version_.micro}")
+        else:
+            new_version = Version(f"{version_.major}.{version_.minor}.{version_.micro + 1}")
     elif version_.dev:
+        # bump and existing pre-release version
         new_version = Version(
             f"{version_.major}.{version_.minor}.{version_.micro}.dev{version_.dev + 1}"
         )
     else:
+        # create the first pre-release version
         new_version = Version(f"{version_.major}.{version_.minor}.{version_.micro}.dev1")
 
     # check that the number of components is correct

--- a/tasks.py
+++ b/tasks.py
@@ -147,7 +147,7 @@ def _bump_version(version_: Version, pre_release: bool) -> Version:
         else:
             new_version = Version(f"{version_.major}.{version_.minor}.{version_.micro + 1}")
     elif version_.dev:
-        # bump and existing pre-release version
+        # bump an existing pre-release version
         new_version = Version(
             f"{version_.major}.{version_.minor}.{version_.micro}.dev{version_.dev + 1}"
         )


### PR DESCRIPTION
Fix pre-release -> standard release logic.

The next release after a pre-release is a non-pre-release version.
```
0.0.1.dev1 -> 0.0.1 -> 0.0.2.dev0 -> 0.0.2dev1 -> 0.0.2
```

Followup to
 - https://github.com/great-expectations/cloud/pull/41


### Note
The actual `0.0.3` release could be cut separately if desired.