### PR TITLE
add `version`/`get-version` invoke task 

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -131,6 +131,12 @@ def _get_local_version() -> Version:
     return Version(_get_pyproject_tool_dict("poetry")["version"])
 
 
+@invoke.task(aliases=["version"])
+def get_version(ctx: Context) -> None:
+    """Print the current package version and exit."""
+    print(_get_local_version())
+
+
 @functools.lru_cache(maxsize=1)
 def _get_latest_version() -> Version:
     r = requests.get("https://pypi.org/pypi/great-expectations-cloud/json")


### PR DESCRIPTION
Simple invoke task for printing the local package version to the console.
Useful for getting the local version as part of the docker tagging step.

```console
$ invoke version     
0.0.6
```