### PR TITLE
enable nightly builds

### DIFF
--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Nightly build, midnight ET
+    # https://crontab.guru/#0_5_*_*_*
+    - cron:  '0 5 * * *'
 
 jobs:
   containerize-agent:
@@ -55,14 +59,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build Test Image
+      # https://docs.docker.com/build/ci/github-actions/test-before-push/
+      - name: Build, No Push
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64
+          push: false
           load: true
           tags: greatexpectations/agent:latest
 
+      # Uses local image built in previous step
       - name: Test New Agent Image
         run: |
           docker compose up -d
@@ -77,7 +84,7 @@ jobs:
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           GE_USAGE_STATISTICS_URL: ${{ secrets.GE_USAGE_STATISTICS_URL }}
 
-      - name: Build and push
+      - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:
           context: .


### PR DESCRIPTION
- Add nightly trigger, so we pick up latest GX without requiring a merge into main
- Document a few steps