### PR TITLE
M/native support mac arm64

### DIFF
--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -60,18 +60,29 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      # https://docs.docker.com/build/ci/github-actions/test-before-push/
-      - name: Build, No Push
+      # Cannot multi arch build AND load
+      # https://github.com/docker/buildx/issues/59
+      - name: Build arm64, No Load, No Push
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
+          load: false
+          tags: greatexpectations/agent:latest
+
+      # https://docs.docker.com/build/ci/github-actions/test-before-push/
+      - name: Build amd64, With Load, No Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
           load: true
           tags: greatexpectations/agent:latest
 
       # Uses local image built in previous step
-      - name: Test New Agent Image
+      - name: Test New amd64 Agent Image
         run: |
           docker compose up -d
           poetry run pytest -m "agentjobs"

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: false
           load: false
           tags: greatexpectations/agent:latest

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - m/native_support_mac_arm64
   schedule:
     # Nightly build, midnight ET
     # https://crontab.guru/#0_5_*_*_*

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -61,10 +61,10 @@ jobs:
 
       # https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Build, No Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           load: true
           tags: greatexpectations/agent:latest

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - m/native_support_mac_arm64
   schedule:
     # Nightly build, midnight ET
     # https://crontab.guru/#0_5_*_*_*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.10.12-slim
+FROM python:3.10.12-slim
 WORKDIR /app/
 
 # File Structure:
@@ -16,7 +16,11 @@ WORKDIR /app/
 ENV PYTHONUNBUFFERED=1
 ENV POETRY_CACHE_DIR=/tmp/pypoetry
 
+# Required for arm64, for building psutil
+RUN apt-get update && apt-get install --no-install-recommends gcc=4:12.2.0-3 -y && rm -rf /var/lib/apt/lists/*
+
 RUN pip --no-cache-dir install poetry==1.6.1
+
 COPY pyproject.toml poetry.lock ./
 
 # Recommended approach for caching build layers with poetry


### PR DESCRIPTION
Support for building and deploying native arm64 container, without QEMU emulation.

380% faster startup to agent connected

```
Internet: 178 mbps

# Before
# Emulating amd64
GX-Agent is ready.
./agent_docker_prod.sh  0.03s user 0.06s system 0% cpu 48.815 total

# After
# Native arm64
GX-Agent is ready.
^CReceived request to shutdown.
Connection to GX Cloud has been closed.
./agent_docker_prod.sh  0.04s user 0.03s system 0% cpu 10.102 total
```

Note: I did a test run and successful with containerize job