### PR TITLE
Update Deprecated SSL Protocol (`DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated`)

### DIFF
--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -225,7 +225,7 @@ class AsyncRabbitMQClient:
         # only enable SSL if connection string calls for it
         if url.startswith("amqps://"):
             # SSL Context for TLS configuration of Amazon MQ for RabbitMQ
-            ssl_context = ssl.SSLContext(ssl.PROFILE_TLS_CLIENT)
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             ssl_context.set_ciphers("ECDHE+AESGCM:!ECDSA")
             parameters.ssl_options = pika.SSLOptions(context=ssl_context)
         return parameters

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -225,7 +225,7 @@ class AsyncRabbitMQClient:
         # only enable SSL if connection string calls for it
         if url.startswith("amqps://"):
             # SSL Context for TLS configuration of Amazon MQ for RabbitMQ
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            ssl_context = ssl.SSLContext(ssl.PROFILE_TLS_CLIENT)
             ssl_context.set_ciphers("ECDHE+AESGCM:!ECDSA")
             parameters.ssl_options = pika.SSLOptions(context=ssl_context)
         return parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.6"
+version = "0.0.7.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Running agent in Docker will emit the following warning: 

```bash
DataContext is ready.
Opening connection to GX Cloud
WARNING:py.warnings:/app/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py:228: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated
  ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)

GX-Agent is ready.
```

This PR updates the protocol to [`PROTOCOL_TLS_CLIENT`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) which will auto-negotiate the highest protocol version between server and client. 

