### PR TITLE
Standardize naming/style/grammar in READMEs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 1. [Install `poetry`](https://python-poetry.org/docs/#installation)
    - [`pipx install poetry`](https://python-poetry.org/docs/#installing-with-pipx)
-2. Setup virtual environment and install dependencies.
+2. Set up virtual environment and install dependencies.
    - `poetry install --sync`
 3. Activate your virtual environment.
    - `poetry shell`
-4. Setup precommit hooks
+4. Set up precommit hooks
    - `pre-commit install`
 
 ### Developer Tasks
@@ -31,28 +31,28 @@ Also available as an invoke task.
 invoke deps
 ```
 
-#### Release to Pypi
+#### Release to PyPI
 
-To release a new version to pypi the version must be incremented.
-New versions are automatically published to pypi when merging to `main`.
+To release a new version to PyPI the version must be incremented.
+New versions are automatically published to PyPI when merging to `main`.
 ```console
 invoke version-bump
 ```
 
 #### Building and Running the GX Agent Image
 
-In order to to build the GX Agent docker image run the following in the root dir:
+To build the GX Agent Docker image, run the following in the root dir:
 
 ```
 invoke build
 ```
 
-Running the agent:
+Running the GX Agent:
 
 ```
 docker run --env GX_CLOUD_ACCESS_TOKEN="<GX_TOKEN>" --env GX_CLOUD_ORGANIZATION_ID="<GX_ORG_ID>" gx/agent
 ```
 
-Now go into GX Cloud and issue commands for the agent to run such as generating an Expectation Suite for a DataSource.
+Now go into GX Cloud and issue commands for the GX Agent to run, such as generating an Expectation Suite for a Data Source.
 
 > Note if you are pushing out a new image update the image tag version in `containerize-agent.yaml`. The image will be built and pushed out via GitHub Actions.

--- a/examples/agent/cloudformation/README.md
+++ b/examples/agent/cloudformation/README.md
@@ -34,9 +34,9 @@
 aws cloudformation create-stack --stack-name gx-agent --template-url https://gx-agent-cloudformation.s3.amazonaws.com/agent-stack.yaml --parameters file://parameters.json --capabilities CAPABILITY_IAM
 ```
 
-1. Go into the AWS Management Console under the CloudFormation page to see that the GX Agent has been spun up. Then go to ECS to see your task running--in the logs you should see that the GX Agent has been spun up.
+6. Go into the AWS Management Console under the CloudFormation page to see that the GX Agent has been spun up. Then go to ECS to see your task running--in the logs you should see that the GX Agent has been spun up.
 
-2. In a browser, go to GX Cloud to start running Checkpoints and fetching metrics.
+7. In a browser, go to GX Cloud to start running Checkpoints and fetching metrics.
 
 # For Devs
 

--- a/examples/agent/cloudformation/README.md
+++ b/examples/agent/cloudformation/README.md
@@ -1,15 +1,15 @@
 # Deploying the GX Agent via CloudFormation
 
-1. Ensure you have the aws cli tool installed and access to the AWS account you will be deploying to. You will need access to ECS, iam and secrets manager.
+1. Ensure you have the AWS CLI tool installed and access to the AWS account you will be deploying to. You will need access to ECS, IAM, and Secrets Manager.
 
-2. Go into AWS secret manager and create a new secret. This secret will hold the following two keys `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID`.
+2. Go into AWS Secrets Manager and create a new secret. This secret will hold the following two keys: `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID`.
 
 - The Organization ID and token can be found and generated in GX Cloud under Settings > Tokens.
-- Copy the ARN of the secret and save this for the `parameters.json`` file later
+- Copy the ARN of the secret and save this for the `parameters.json` file later
 
-3. Go into the AWS console and find the subnet group and security group that you would like the GX Agent container to use. Copy the resource id for each of these, they should take a form similar to `sg-abcd1234` and `subnet-abcd1234`.
+3. Go into the AWS Management Console and find the subnet group and security group that you would like the GX Agent container to use. Copy the resource ID for each of these; they should use a format similar to `sg-abcd1234` or `subnet-abcd1234`.
 
-4. Open up a terminal and create a file named `parameters.json`. In the parameters.json file paste the following and add in your arn and resource values that you copied from the previous steps.
+4. Open up a terminal and create a file named `parameters.json`. In the `parameters.json` file, paste the following and add in your ARN and resource values that you copied from the previous steps.
 
 ```
 [
@@ -28,17 +28,17 @@
 ]
 ```
 
-5. Create the cloudformation stack
+5. Create the CloudFormation stack
 
 ```
 aws cloudformation create-stack --stack-name gx-agent --template-url https://gx-agent-cloudformation.s3.amazonaws.com/agent-stack.yaml --parameters file://parameters.json --capabilities CAPABILITY_IAM
 ```
 
-6. Go into the AWS console under the CloudFormation page to see that the gx-agent has been spun up. Then go to ECS to see your task running, in the logs you should see that the agent has spun up.
+1. Go into the AWS Management Console under the CloudFormation page to see that the GX Agent has been spun up. Then go to ECS to see your task running--in the logs you should see that the GX Agent has been spun up.
 
-7. In a browser go to GX Cloud to start running validation and fetching metrics.
+2. In a browser, go to GX Cloud to start running Checkpoints and fetching metrics.
 
 # For Devs
 
-Upload the cloudformation template to s3
+Upload the CloudFormation template to s3
 `aws s3 cp agent-stack.yaml <s3://s3-bucket/path-to-stack-file>`

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -64,13 +64,13 @@ class GXAgent:
     """
     Run GX in any environment from GX Cloud.
 
-    To start the agent, install Python and great_expectations and run `gx-agent`.
-    The agent loads a DataContext configuration from GX Cloud, and listens for
+    To start the GX Agent, install Python and great_expectations and run `gx-agent`.
+    The GX Agent loads a DataContext configuration from GX Cloud, and listens for
     user events triggered from the UI.
     """
 
     def __init__(self: Self):
-        print("Initializing GX-Agent")
+        print("Initializing the GX Agent")
         self._config = self._get_config()
         print("Loading a DataContext - this might take a moment.")
         self._context: CloudDataContext = get_context(cloud_mode=True)
@@ -97,7 +97,7 @@ class GXAgent:
         try:
             client = AsyncRabbitMQClient(url=str(self._config.connection_string))
             subscriber = Subscriber(client=client)
-            print("GX-Agent is ready.")
+            print("The GX Agent is ready.")
             # Open a connection until encountering a shutdown event
             subscriber.consume(
                 queue=self._config.queue,

--- a/tasks.py
+++ b/tasks.py
@@ -113,7 +113,7 @@ def deps(ctx: Context) -> None:
 
 @invoke.task
 def build(ctx: Context) -> None:
-    """Build GX Agent Image"""
+    """Build the GX Agent Image"""
     cmds = [
         "docker",
         "buildx",

--- a/tests/agent/jobs/test_job_processing.py
+++ b/tests/agent/jobs/test_job_processing.py
@@ -21,7 +21,7 @@ def local_gql_url(gx_agent_vars: GxAgentEnvVars) -> str:
 # Retry for 3 minutes, if agent is not ready then assume something went wrong
 @retry(stop=stop_after_delay(180))
 def ensure_agent_is_ready(local_gql_url: str, token: str):
-    """Throw an HTTP or ConnectionError exception if the agent is not ready"""
+    """Throw an HTTP or ConnectionError exception if the GX Agent is not ready"""
     body = """
         query agent_status {
             agentStatus {


### PR DESCRIPTION
Came across some instances where we were saying "agent" instead of "the GX Agent". Updated these and also updated some style/grammar along the way to better adhere to the styleguide