### PR TITLE
[MAINTENANCE] Remove schedule for containerizing the agent

### DIFF
--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # Nightly build, midnight ET
-    # https://crontab.guru/#0_5_*_*_*
-    - cron:  '0 5 * * *'
 
 jobs:
   containerize-agent:


### PR DESCRIPTION
Removing so we don't overwrite the agent build nightly.