### PR TITLE
Bump Docker GX OSS version to `0.18.7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ Also available as an invoke task.
 invoke deps
 ```
 
-#### Release to PyPI
+#### Release to PyPI and Docker
 
 To release a new version to PyPI the version must be incremented.
 New versions are automatically published to PyPI when merging to `main`.
 ```console
 invoke version-bump
 ```
+
+A new docker tag will also be generated and pushed to [dockerhub](https://hub.docker.com/r/greatexpectations/agent).
 
 #### Building and Running the GX Agent Image
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Also available as an invoke task.
 invoke deps
 ```
 
+#### Updating `poetry.lock` dependencies
+
+The dependencies installed in our CI and the docker build step are determined by the [poetry.lock file](https://python-poetry.org/docs/basic-usage/#installing-with-poetrylock).
+
+[To update only a specific dependency](https://python-poetry.org/docs/cli/#update) (such as `great_expectations`) ...
+```console
+poetry update great_expectations
+```
+
+[To resolve and update all dependencies ...](https://python-poetry.org/docs/cli/#lock)
+```console
+poetry lock
+```
+
+In either case, the updated `poetry.lock` file must be committed and merged to main.
+
+
 #### Release to PyPI and Docker
 
 To release a new version to PyPI the version must be incremented.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ New versions are automatically published to PyPI when merging to `main`.
 invoke version-bump
 ```
 
-A new docker tag will also be generated and pushed to [dockerhub](https://hub.docker.com/r/greatexpectations/agent).
+A new docker tag will also be generated and pushed to [Docker Hub](https://hub.docker.com/r/greatexpectations/agent).
 
 #### Building and Running the GX Agent Image
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -752,13 +752,13 @@ files = [
 
 [[package]]
 name = "great-expectations"
-version = "0.18.6"
+version = "0.18.7"
 description = "Always know what to expect from your data."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "great_expectations-0.18.6-py3-none-any.whl", hash = "sha256:3308596cb628fba79cf55c891f6f17a30e6784e88dbb296000d937ea7f4e602b"},
-    {file = "great_expectations-0.18.6.tar.gz", hash = "sha256:71b3282284a3455540ea413093ce5d13cab245eedf865763542edf6b472eac6b"},
+    {file = "great_expectations-0.18.7-py3-none-any.whl", hash = "sha256:9f7f3c0c6ae5d5188ef8a531053449d98e9ce1b1e8565aef637056319c6ab301"},
+    {file = "great_expectations-0.18.7.tar.gz", hash = "sha256:6fbf9b93cd870c1951f3e8dd5b44673bcd45dd3e14407857181754116aecb2bc"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.14"
+version = "0.0.15"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Bump Docker GX OSS version to `0.18.7`

Update README

Added instructions for updating Dockerfile dependencies (the `poetry.lock` file)