### PR TITLE
Test connection before running CDM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     # This job checks that the version in the PR is different than the version in main if the agent has changed.
     needs: check-if-agent-changed
     runs-on: ubuntu-latest
-    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'true' && github.event_name != 'schedule' }}
+    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'agent' && github.event_name != 'schedule' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'schedule' }}
     outputs:
-      agent_changed: ${{ steps.check_agent.outputs.agent_changed }}
+      agent_changed: ${{ steps.filter.outputs.agent }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,10 +24,10 @@ jobs:
 
 
   check-version-is-bumped:
-    # This job checks that the version in the PR is different than the version in main if the agent has changed.
+    # This job checks that the version in the PR is different from the version in main if the agent has changed.
     needs: check-if-agent-changed
     runs-on: ubuntu-latest
-    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'agent' && github.event_name != 'schedule' }}
+    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'true' && github.event_name != 'schedule' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           filters: |
             agent:
-              - 'great_expectations_cloud/agent/*'
+              - 'great_expectations_cloud/agent/**'
 
 
   check-version-is-bumped:

--- a/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
@@ -28,6 +28,7 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
     @override
     def run(self, event: RunColumnDescriptiveMetricsEvent, id: str) -> ActionResult:
         datasource = self._context.get_datasource(event.datasource_name)
+        datasource.test_connection(test_assets=True)  # raises `TestConnectionError` on failure
         data_asset = datasource.get_asset(event.data_asset_name)
         batch_request = data_asset.build_batch_request()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.15"
+version = "0.0.16"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Test that we can connect to the datasource before running CDM. The `datasource.test_connection()` method raises a human readable warning that will be visible in the agent logs.
Demo: https://us02web.zoom.us/clips/share/EMmyDoL7rscoKeGl8ZuA0gNtiy3tatwrWslCejOBP296l4dqAI6VSowtROnL1oUtvhK55Ii7MRmgOrAdjbYJ5-Mf.8w-XnYgbkmOcQKtK