### PR TITLE
Fix filter for check if agent changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'schedule' }}
     outputs:
-      agent_changed: ${{ steps.check_agent.outputs.agent_changed }}
+      agent_changed: ${{ steps.filter.outputs.agent }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,11 +20,11 @@ jobs:
         with:
           filters: |
             agent:
-              - 'great_expectations_cloud/agent/*'
+              - 'great_expectations_cloud/agent/**'
 
 
   check-version-is-bumped:
-    # This job checks that the version in the PR is different than the version in main if the agent has changed.
+    # This job checks that the version in the PR is different from the version in main if the agent has changed.
     needs: check-if-agent-changed
     runs-on: ubuntu-latest
     if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'true' && github.event_name != 'schedule' }}


### PR DESCRIPTION
The filter was not catching changes in https://github.com/great-expectations/cloud/pull/91. These changes make sure we are checking all subfolders for changed files.
See failing then passing test after version bump in https://github.com/great-expectations/cloud/pull/91 to verify this is working:
![image](https://github.com/great-expectations/cloud/assets/9903066/52c23127-96a5-4386-a0f0-a13e550402cd)
