### PR TITLE
Set `User-Agent: gx-agent`& `Agent-Job-Id` on GX Cloud API requests 

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -298,7 +298,11 @@ class GXAgent:
     def _set_http_session_headers(correlation_id: str | None = None) -> None:
         """
         Set the the session headers for requests to GX Cloud.
-        In particular, set the User-Agent header to identify the GX Agent and the correlation_id if provided.
+        In particular, set the User-Agent header to identify the GX Agent and the correlation_id as
+        Agent-Job-id if provided.
+
+        Note: the Agent-Job-Id header value will be set for all GX Cloud request until this method is
+        called again.
         """
         from great_expectations import __version__
         from great_expectations.core import http
@@ -307,7 +311,9 @@ class GXAgent:
             "0.19"  # using 0.19 instead of 1.0 to account for pre-releases
         ):
             # TODO: public API should be available in v1
-            LOGGER.info("Unable to set User-Agent header for requests to GX Cloud")
+            LOGGER.info(
+                f"Unable to set {HeaderName.USER_AGENT} or {HeaderName.AGENT_JOB_ID} header for requests to GX Cloud"
+            )
             return
 
         def _update_headers_agent_patch(

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -81,7 +81,7 @@ class GXAgent:
     def __init__(self: Self):
         agent_version: str = self._get_current_gx_agent_version()
         print(f"GX Agent version: {agent_version}")
-        print(f"Initializing the GX Agent version: {agent_version}.")
+        print("Initializing the GX Agent.")
         self._config = self._get_config()
         self._set_http_session_headers()
         print("Loading a DataContext - this might take a moment.")

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -320,7 +320,7 @@ class GXAgent:
                 HeaderName.USER_AGENT: USER_AGENT_HEADER,
             }
             if correlation_id:
-                headers[HeaderName.CORRELATION_ID] = correlation_id
+                headers[HeaderName.AGENT_JOB_ID] = correlation_id
             session.headers.update(headers)
             return session
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -295,8 +295,8 @@ class GXAgent:
         data = status.json()
         session.patch(agent_sessions_url, data=data)
 
-    @staticmethod
-    def _set_http_session_headers(correlation_id: str | None = None) -> None:
+    @classmethod
+    def _set_http_session_headers(cls, correlation_id: str | None = None) -> None:
         """
         Set the the session headers for requests to GX Cloud.
         In particular, set the User-Agent header to identify the GX Agent and the correlation_id as
@@ -324,7 +324,7 @@ class GXAgent:
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": f"Bearer {access_token}",
                 "Gx-Version": __version__,
-                HeaderName.USER_AGENT: USER_AGENT_HEADER,
+                HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{cls._get_current_gx_agent_version()}",
             }
             if correlation_id:
                 headers[HeaderName.AGENT_JOB_ID] = correlation_id

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -19,7 +19,7 @@ from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_U
 from packaging.version import Version
 
 from great_expectations_cloud.agent.config import GxAgentEnvVars
-from great_expectations_cloud.agent.constants import USER_AGENT_HEADER
+from great_expectations_cloud.agent.constants import USER_AGENT_HEADER, HeaderName
 from great_expectations_cloud.agent.event_handler import (
     EventHandler,
 )
@@ -317,10 +317,10 @@ class GXAgent:
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": f"Bearer {access_token}",
                 "Gx-Version": __version__,
-                "User-Agent": USER_AGENT_HEADER,
+                HeaderName.USER_AGENT: USER_AGENT_HEADER,
             }
             if correlation_id:
-                headers["Correlation-Id"] = correlation_id
+                headers[HeaderName.CORRELATION_ID] = correlation_id
             session.headers.update(headers)
             return session
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -16,6 +16,7 @@ from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pydantic import AmqpDsn, AnyUrl
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
+from packaging.version import Version
 
 from great_expectations_cloud.agent.config import GxAgentEnvVars
 from great_expectations_cloud.agent.constants import USER_AGENT_HEADER
@@ -296,6 +297,13 @@ class GXAgent:
         from great_expectations import __version__
         from great_expectations.core import http
 
+        if Version(__version__) > Version(
+            "0.19"  # using 0.19 instead of 1.0 to account for pre-releases
+        ):
+            # TODO: public API should be available in v1
+            LOGGER.info("Unable to set User-Agent header for requests to GX Cloud")
+            return
+
         def _update_headers_agent_patch(
             session: requests.Session, access_token: str
         ) -> requests.Session:
@@ -308,6 +316,8 @@ class GXAgent:
             session.headers.update(headers)
             return session
 
+        # TODO: this is relying on a private implementation detail
+        # use a public API once it is available
         http._update_headers = _update_headers_agent_patch
 
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -80,6 +80,7 @@ class GXAgent:
 
     def __init__(self: Self):
         agent_version: str = self._get_current_gx_agent_version()
+        print(f"GX Agent version: {agent_version}")
         print(f"Initializing the GX Agent version: {agent_version}.")
         self._config = self._get_config()
         self._set_http_session_headers()
@@ -127,9 +128,9 @@ class GXAgent:
             if subscriber is not None:
                 subscriber.close()
 
-    def _get_current_gx_agent_version(self) -> str:
-        version: str = metadata_version(self._PYPI_GX_AGENT_PACKAGE_NAME)
-        print(f"GX Agent version: {version}")
+    @classmethod
+    def _get_current_gx_agent_version(cls) -> str:
+        version: str = metadata_version(cls._PYPI_GX_AGENT_PACKAGE_NAME)
         return version
 
     def _handle_event_as_thread_enter(self, event_context: EventContext) -> None:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -155,7 +155,7 @@ class GXAgent:
             loop.create_task(event_context.redeliver_message())
             return
 
-        # ensusre that great_expectations.http requests to GX Cloud include the job_id/correlation_id
+        # ensure that great_expectations.http requests to GX Cloud include the job_id/correlation_id
         self._set_http_session_headers(correlation_id=event_context.correlation_id)
 
         # send this message to a thread for processing

--- a/great_expectations_cloud/agent/constants.py
+++ b/great_expectations_cloud/agent/constants.py
@@ -1,0 +1,5 @@
+from typing import Final
+
+USER_AGENT_HEADER: Final[str] = "gx-agent"
+
+__all__ = ["USER_AGENT_HEADER"]

--- a/great_expectations_cloud/agent/constants.py
+++ b/great_expectations_cloud/agent/constants.py
@@ -6,7 +6,7 @@ from typing import Final
 
 class HeaderName(str, enum.Enum):
     USER_AGENT = "User-Agent"
-    CORRELATION_ID = "Correlation-ID"
+    AGENT_JOB_ID = "Agent-Job-Id"
 
 
 USER_AGENT_HEADER: Final = "gx-agent"

--- a/great_expectations_cloud/agent/constants.py
+++ b/great_expectations_cloud/agent/constants.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import enum
 from typing import Final
 
-USER_AGENT_HEADER: Final[str] = "gx-agent"
+
+class HeaderName(str, enum.Enum):
+    USER_AGENT = "User-Agent"
+    CORRELATION_ID = "Correlation-ID"
+
+
+USER_AGENT_HEADER: Final = "gx-agent"
 
 __all__ = ["USER_AGENT_HEADER"]

--- a/great_expectations_cloud/agent/constants.py
+++ b/great_expectations_cloud/agent/constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Final
 
 USER_AGENT_HEADER: Final[str] = "gx-agent"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2005,14 +2005,17 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "21.3"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
@@ -3887,4 +3890,4 @@ snowflake = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "8ad1f0d6c3b72770be45ad04e4d410a5f696c058e9b3013c8bf96c025d289552"
+content-hash = "f06d505e02472a1dfba8e27476bf973419b7d62a1c4471e4f74492a004cf0a2f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3887,4 +3887,4 @@ snowflake = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "54a1a75b5df782b0ddaeddf6f4ef116597295b98d8a186885a860151f96af84d"
+content-hash = "8ad1f0d6c3b72770be45ad04e4d410a5f696c058e9b3013c8bf96c025d289552"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ runtime-evaluated-base-classes = [
     "great_expectations.datasource.fluent.fluent_base_model.FluentBaseModel",
     "great_expectations.datasource.fluent.interfaces.Datasource",
     "great_expectations.datasource.fluent.sql_datasource.SQLDatasource",
+    "great_expectations_cloud.agent.models.AgentBaseModel",
 ]
 runtime-evaluated-decorators = ["pydantic.dataclasses.dataclass"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ pydantic = "<3"
 pika = "^1.3.1"
 # needed for metrics serialization
 orjson = "^3.9.7, !=3.9.10" # TODO: remove inequality once dep resolution issue is resolved
+# relying on packaging in agent code so declaring it explicitly here
+packaging = "^21.3"
 
 [tool.poetry.extras]
 snowflake = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ runtime-evaluated-base-classes = [
     "great_expectations.datasource.fluent.fluent_base_model.FluentBaseModel",
     "great_expectations.datasource.fluent.interfaces.Datasource",
     "great_expectations.datasource.fluent.sql_datasource.SQLDatasource",
-    "great_expectations_cloud.agent.models.AgentBaseModel",
 ]
 runtime-evaluated-decorators = ["pydantic.dataclasses.dataclass"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.19.dev0"
+version = "0.0.19"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from great_expectations import __version__ as gx_version
+from packaging.version import Version
+
+
+@pytest.fixture
+def mock_gx_version_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mock the response from pypi.org for the great_expectations package"""
+
+    def _mock_get_lastest_version_from_pypi(self) -> Version:
+        return Version(gx_version)
+
+    monkeypatch.setattr(
+        "great_expectations.data_context._version_checker._VersionChecker._get_latest_version_from_pypi",
+        _mock_get_lastest_version_from_pypi,
+        raising=True,
+    )
+
+
+@pytest.fixture
+def gx_logging_info(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """Set up logging for the gx package"""
+    with caplog.at_level(logging.INFO, logger="great_expectations"):
+        yield caplog

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 import pytest
 from great_expectations import __version__ as gx_version
 from packaging.version import Version
@@ -21,10 +19,3 @@ def mock_gx_version_check(
         _mock_get_lastest_version_from_pypi,
         raising=True,
     )
-
-
-@pytest.fixture
-def gx_logging_info(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
-    """Set up logging for the gx package"""
-    with caplog.at_level(logging.INFO, logger="great_expectations"):
-        yield caplog

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import logging
+from collections import deque
+from typing import Any
+
 import pytest
 from great_expectations import __version__ as gx_version
 from packaging.version import Version
+from typing_extensions import override
+
+from great_expectations_cloud.agent.message_service.subscriber import OnMessageCallback, Subscriber
+from great_expectations_cloud.agent.models import Event
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -19,3 +29,33 @@ def mock_gx_version_check(
         _mock_get_lastest_version_from_pypi,
         raising=True,
     )
+
+
+class FakeSubscriber(Subscriber):
+    test_queue: deque[Event]
+
+    def __init__(self, client: Any, test_events: list[Event] | None = None):
+        self.client = client
+        self.test_queue = deque()
+        if test_events:
+            self.test_queue.extend(test_events)
+
+    @override
+    def consume(self, queue: str, on_message: OnMessageCallback) -> None:
+        print(on_message)
+        while self.test_queue:
+            # TODO: parse and handle the event
+            msg = self.test_queue.pop()
+            LOGGER.info(f"FakeSubscriber.consume() received {msg}")
+
+    @override
+    def close(self) -> None:
+        LOGGER.info(f"{self.__class__.__name__}.close() called")
+
+
+@pytest.fixture
+def fake_subscriber(mocker) -> FakeSubscriber:
+    """Patch the agent.Subscriber constuctor to return a FakeSubscriber that pulls from a `.test_queue` in-memory list."""
+    subscriber = FakeSubscriber(client=object())
+    mocker.patch("great_expectations_cloud.agent.agent.Subscriber", return_value=subscriber)
+    return subscriber

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -236,7 +236,6 @@ def test_gx_agent_updates_cloud_on_job_status(
 
 
 def test_custom_user_agent(
-    gx_logging_info,
     mock_gx_version_check: None,
     set_required_env_vars: None,
     gx_agent_config: GXAgentConfig,

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -12,6 +12,7 @@ import responses
 from great_expectations_cloud.agent import GXAgent
 from great_expectations_cloud.agent.actions.agent_action import ActionResult
 from great_expectations_cloud.agent.agent import GXAgentConfig
+from great_expectations_cloud.agent.constants import USER_AGENT_HEADER
 from great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client import (
     ClientError,
 )
@@ -303,5 +304,7 @@ def test_custom_user_agent(
                     },
                 },
             },
+            # match will fail if the User-Agent header is not set
+            match=[responses.matchers.header_matcher({"User-Agent": USER_AGENT_HEADER})],
         )
         GXAgent()

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -258,7 +258,13 @@ def test_custom_user_agent(
                 "stores": {},
             },
             # match will fail if the User-Agent header is not set
-            match=[responses.matchers.header_matcher({HeaderName.USER_AGENT: USER_AGENT_HEADER})],
+            match=[
+                responses.matchers.header_matcher(
+                    {
+                        HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{GXAgent._get_current_gx_agent_version()}"
+                    }
+                )
+            ],
         )
         GXAgent()
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -303,7 +303,7 @@ def test_correlation_id_header(
             json={},
             # match will fail if correlation-id header is not set
             match=[
-                responses.matchers.header_matcher({HeaderName.CORRELATION_ID: str(agent_job_id_1)})
+                responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: str(agent_job_id_1)})
             ],
         )
         rsps.add(
@@ -312,7 +312,7 @@ def test_correlation_id_header(
             json={},
             # match will fail if correlation-id header is not set
             match=[
-                responses.matchers.header_matcher({HeaderName.CORRELATION_ID: str(agent_job_id_2)})
+                responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: str(agent_job_id_2)})
             ],
         )
         agent = GXAgent()

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -247,7 +247,6 @@ def test_custom_user_agent(
         rsps.add(
             responses.GET,
             f"{base_url}/organizations/{org_id}/data-context-configuration",
-            # TODO: move the elsewhere (use VCR'ish yaml?)
             json={
                 "anonymous_usage_statistics": {
                     "data_context_id": str(uuid.uuid4()),

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -254,54 +254,7 @@ def test_custom_user_agent(
                     "enabled": False,
                 },
                 "datasources": {},
-                "checkpoint_store_name": "default_checkpoint_store",
-                "expectations_store_name": "default_expectations_store",
-                "evaluation_parameter_store_name": "default_evaluation_parameter_store",
-                "validations_store_name": "default_validations_store",
-                "stores": {
-                    "default_evaluation_parameter_store": {
-                        "class_name": "EvaluationParameterStore"
-                    },
-                    "default_expectations_store": {
-                        "class_name": "ExpectationsStore",
-                        "store_backend": {
-                            "class_name": "GXCloudStoreBackend",
-                            "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
-                            "ge_cloud_credentials": {
-                                "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
-                                "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
-                            },
-                            "ge_cloud_resource_type": "expectation_suite",
-                            "suppress_store_backend_id": True,
-                        },
-                    },
-                    "default_checkpoint_store": {
-                        "class_name": "CheckpointStore",
-                        "store_backend": {
-                            "class_name": "GXCloudStoreBackend",
-                            "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
-                            "ge_cloud_credentials": {
-                                "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
-                                "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
-                            },
-                            "ge_cloud_resource_type": "checkpoint",
-                            "suppress_store_backend_id": True,
-                        },
-                    },
-                    "default_validations_store": {
-                        "class_name": "ValidationsStore",
-                        "store_backend": {
-                            "class_name": "GXCloudStoreBackend",
-                            "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
-                            "ge_cloud_credentials": {
-                                "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
-                                "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
-                            },
-                            "ge_cloud_resource_type": "validation_result",
-                            "suppress_store_backend_id": True,
-                        },
-                    },
-                },
+                "stores": {},
             },
             # match will fail if the User-Agent header is not set
             match=[responses.matchers.header_matcher({"User-Agent": USER_AGENT_HEADER})],


### PR DESCRIPTION
Ensure that a `User-Agent: gx-agent/<AGENT_VERSION>` header is always set when making calls to the GX Cloud REST API.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

Doing this so that we can differentiate between API calls coming from the `gx-agent` vs standard `great_expectations`.

In the context of a job, the `Agent-Job-Id` header is also set on every API request.

### Implementation Notes

The header details are controlled in `great_expectations.core.http` by non-public methods so I had to monkeypatch one of these methods to ensure the header is properly set.

For the V1 release, we should expose a public method of doing this operation, and then this implementation can be changed. I will implement this in a followup so as not to force a new `0.18.x` release.