### PR TITLE
Update LICENSE to use "GX Agent" instead of "GX Cloud Agent"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
-The GX Cloud Agent License
-Copyright 2023 Great Expectations Labs, Inc.
+The GX Agent License
+Copyright 2024 Great Expectations Labs, Inc.
 
-Licensed under the Great Expectations Labs GX Cloud Agent License (the "License"); you may not use this software and associated documentation (the "Software") except in compliance with the License. You may obtain a copy of the License at https://github.com/great-expectations/cloud/blob/main/LICENSE.
+Licensed under the Great Expectations Labs GX Agent License (the “License”); you may not use this software and associated documentation (the “Software”) except in compliance with the License. You may obtain a copy of the License at https://github.com/great-expectations/cloud/blob/main/LICENSE.
 
 You may use the Software only if you (and an organization that you represent) have agreed to and are in compliance with the Great Expectations Labs Terms of Service, found at https://greatexpectations.io/terms-of-service, or other agreement governing the use of the Software, as agreed upon by you and Great Expectations Labs, and if you also have a valid GX Cloud subscription.
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non infringement. See the License for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non infringement. See the License for the specific language governing permissions and limitations under the License.
 
-GX Cloud Agent License Additional Terms:
+The GX Agent License Additional Terms:
 
 1. Usage Restriction: You are granted a limited, non-exclusive license to use the code solely for the purpose of using GX Cloud in accordance with the Great Expectations Labs Terms of Service. Any other use, including but not limited to modification, distribution, or reuse of the code, is strictly prohibited.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 The GX Agent License
 Copyright 2024 Great Expectations Labs, Inc.
 
-Licensed under the Great Expectations Labs GX Agent License (the “License”); you may not use this software and associated documentation (the “Software”) except in compliance with the License. You may obtain a copy of the License at https://github.com/great-expectations/cloud/blob/main/LICENSE.
+Licensed under the Great Expectations Labs GX Agent License (the "License"); you may not use this software and associated documentation (the "Software") except in compliance with the License. You may obtain a copy of the License at https://github.com/great-expectations/cloud/blob/main/LICENSE.
 
 You may use the Software only if you (and an organization that you represent) have agreed to and are in compliance with the Great Expectations Labs Terms of Service, found at https://greatexpectations.io/terms-of-service, or other agreement governing the use of the Software, as agreed upon by you and Great Expectations Labs, and if you also have a valid GX Cloud subscription.
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non infringement. See the License for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and non infringement. See the License for the specific language governing permissions and limitations under the License.
 
 The GX Agent License Additional Terms:
 


### PR DESCRIPTION
Update terminology to match product glossary - text document was provided in this thread: https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1705598882375079?thread_ts=1701803742.800279&cid=C05R8RE43CL