### PR TITLE
F/zel 276/surface gx version in agent startup

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -107,7 +107,7 @@ class GXAgent:
     def run(self) -> None:
         """Open a connection to GX Cloud."""
 
-        print("Opening connection to GX Cloud")
+        print("Opening connection to GX Cloud.")
         self._listen()
         print("Connection to GX Cloud has been closed.")
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -77,10 +77,13 @@ class GXAgent:
     """
 
     _PYPI_GX_AGENT_PACKAGE_NAME = "great_expectations_cloud"
+    _PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME = "great_expectations"
 
     def __init__(self: Self):
         agent_version: str = self._get_current_gx_agent_version()
+        great_expectations_version: str = self._get_current_great_expectations_version()
         print(f"GX Agent version: {agent_version}")
+        print(f"Great Expectations version: {great_expectations_version}")
         print("Initializing the GX Agent.")
         self._config = self._get_config()
         self._set_http_session_headers()
@@ -131,6 +134,11 @@ class GXAgent:
     @classmethod
     def _get_current_gx_agent_version(cls) -> str:
         version: str = metadata_version(cls._PYPI_GX_AGENT_PACKAGE_NAME)
+        return version
+
+    @classmethod
+    def _get_current_great_expectations_version(cls) -> str:
+        version: str = metadata_version(cls._PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME)
         return version
 
     def _handle_event_as_thread_enter(self, event_context: EventContext) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.19"
+version = "0.0.20"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Talked to @Kilo59 about the comment [here](https://github.com/great-expectations/cloud/pull/95#discussion_r1457834597). We decided it would be helpful to surface the version of GX being used by the agent here so that users who don't use the Docker image can easily see which version of GX is being used.

Example startup printout with this change:
![image](https://github.com/great-expectations/cloud/assets/32279443/ff1f0b1a-34ed-420d-9a85-c00e190273d8)
