### PR TITLE
update agent printout error message for clarity

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -210,13 +210,12 @@ class GXAgent:
                 success=True,
                 created_resources=result.created_resources,
             )
-            print(f"Completed job {event_context.event.type} ({event_context.correlation_id})")
+            print(f"Completed job: {event_context.event.type} ({event_context.correlation_id})")
         else:
             status = JobCompleted(success=False, error_stack_trace=str(error))
             print(traceback.format_exc())
             print(
-                f"Failed to complete job {event_context.event.type} "
-                f"({event_context.correlation_id})"
+                f"Job completed with error: {event_context.event.type} ({event_context.correlation_id})"
             )
         self._update_status(job_id=event_context.correlation_id, status=status)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.20"
+version = "0.0.21"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Prior to this change, users noted some confusion about the error message used in the GX Agent printout, since sometimes this error message happens when a job is completed with errors (as opposed to when a job fails to complete), like when testing Data Source config.

For that reason I updated the error message to indicate that the job completed with errors. Future enhancements could add a more-specific message, but this should be fine for now.

Before change:
![image](https://github.com/great-expectations/cloud/assets/32279443/1c19e042-56fc-47e0-b49f-ade82feba8ba)

After change:
![image](https://github.com/great-expectations/cloud/assets/32279443/61b8d263-fd44-4e6c-8635-dfb215b91a9f)
