### PR TITLE
Revert "Configure Dependabot Version Updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
-version: 2
-updates:
-  - package-ecosystem: "poetry" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Reverts great-expectations/cloud#105

It looks like maybe this isn't ready for prime time yet. Getting a "invalid details" error using `poetry` as the `package-ecosystem` here: https://github.com/great-expectations/cloud/runs/20914663368
Even though poetry is listed on the list of supported package ecosystems: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem