### PR TITLE
Add `yellow_tripdata.db` to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN poetry install --with sql --without dev --no-root --no-directory
 
 COPY README.md README.md
 COPY great_expectations_cloud great_expectations_cloud
-COPY examples/data data
+COPY examples/agent/data data
 
 RUN poetry install --only-root && rm -rf POETRY_CACHE_DIR
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN poetry install --with sql --without dev --no-root --no-directory
 
 COPY README.md README.md
 COPY great_expectations_cloud great_expectations_cloud
+COPY examples/data data
 
 RUN poetry install --only-root && rm -rf POETRY_CACHE_DIR
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ docker run --env GX_CLOUD_ACCESS_TOKEN="<GX_TOKEN>" --env GX_CLOUD_ORGANIZATION_
 Now go into GX Cloud and issue commands for the GX Agent to run, such as generating an Expectation Suite for a Data Source.
 
 > Note if you are pushing out a new image update the image tag version in `containerize-agent.yaml`. The image will be built and pushed out via GitHub Actions.
+
+
+#### Example Data
+The contents from [/examples/agent/data](/examples/agent/data/) will be copied to `/data` for the docker container.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.22"
+version = "0.0.23.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Adds `yellow_tripdata.db` (7MB) sqlite database to the docker image.

This ensures that every agent has access to some data they can connect to explore and run agent-powered interactions from the cloud.