### PR TITLE
Fix missing `Agent-Job-Id` for `CheckpointRun` events 

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -164,7 +164,6 @@ class GXAgent:
             return
 
         # ensure that great_expectations.http requests to GX Cloud include the job_id/correlation_id
-        assert event_context.correlation_id  # TODO: remove this
         self._set_http_session_headers(correlation_id=event_context.correlation_id)
 
         # send this message to a thread for processing

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -314,6 +314,7 @@ class GXAgent:
         """
         from great_expectations import __version__
         from great_expectations.core import http
+        from great_expectations.data_context.store.gx_cloud_store_backend import GXCloudStoreBackend
 
         if Version(__version__) > Version(
             "0.19"  # using 0.19 instead of 1.0 to account for pre-releases
@@ -332,7 +333,9 @@ class GXAgent:
         if correlation_id:
             # OSS doesn't use the same session for all requests, so we need to set the header for each store
             for store in self._context.stores.values():
-                store._store_backend._session.headers[HeaderName.AGENT_JOB_ID] = correlation_id
+                backend = store._store_backend
+                if isinstance(backend, GXCloudStoreBackend):
+                    backend._session.headers[HeaderName.AGENT_JOB_ID] = correlation_id
 
         def _update_headers_agent_patch(
             session: requests.Session, access_token: str

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -85,8 +85,8 @@ class GXAgent:
         print(f"GX Agent version: {agent_version}")
         print(f"Great Expectations version: {great_expectations_version}")
         print("Initializing the GX Agent.")
-        self._config = self._get_config()
         self._set_http_session_headers()
+        self._config = self._get_config()
         print("Loading a DataContext - this might take a moment.")
 
         with warnings.catch_warnings():
@@ -303,8 +303,7 @@ class GXAgent:
         data = status.json()
         session.patch(agent_sessions_url, data=data)
 
-    @classmethod
-    def _set_http_session_headers(cls, correlation_id: str | None = None) -> None:
+    def _set_http_session_headers(self, correlation_id: str | None = None) -> None:
         """
         Set the the session headers for requests to GX Cloud.
         In particular, set the User-Agent header to identify the GX Agent and the correlation_id as
@@ -325,7 +324,7 @@ class GXAgent:
             )
             return
 
-        agent_version = cls._get_current_gx_agent_version()
+        agent_version = self._get_current_gx_agent_version()
         LOGGER.info(
             f"Setting session headers for GX Cloud. {HeaderName.USER_AGENT}:{agent_version} {HeaderName.AGENT_JOB_ID}:{correlation_id}"
         )
@@ -338,7 +337,7 @@ class GXAgent:
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": f"Bearer {access_token}",
                 "Gx-Version": __version__,
-                HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{cls._get_current_gx_agent_version()}",
+                HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{agent_version}",
             }
             if correlation_id:
                 headers[HeaderName.AGENT_JOB_ID] = correlation_id

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -325,7 +325,7 @@ class GXAgent:
             return
 
         agent_version = self._get_current_gx_agent_version()
-        LOGGER.info(
+        LOGGER.debug(
             f"Setting session headers for GX Cloud. {HeaderName.USER_AGENT}:{agent_version} {HeaderName.AGENT_JOB_ID}:{correlation_id}"
         )
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -164,6 +164,7 @@ class GXAgent:
             return
 
         # ensure that great_expectations.http requests to GX Cloud include the job_id/correlation_id
+        assert event_context.correlation_id  # TODO: remove this
         self._set_http_session_headers(correlation_id=event_context.correlation_id)
 
         # send this message to a thread for processing

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -324,9 +324,15 @@ class GXAgent:
             )
             return
 
+        agent_version = cls._get_current_gx_agent_version()
+        LOGGER.info(
+            f"Setting session headers for GX Cloud. {HeaderName.USER_AGENT}:{agent_version} {HeaderName.AGENT_JOB_ID}:{correlation_id}"
+        )
+
         def _update_headers_agent_patch(
             session: requests.Session, access_token: str
         ) -> requests.Session:
+            LOGGER.debug("Updating headers for GX Cloud session")
             headers = {
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": f"Bearer {access_token}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.23.dev0"
+version = "0.0.23"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from collections import deque
-from typing import Any, Iterable, NamedTuple
+from typing import Any, Iterable, NamedTuple, TypedDict
 
 import pytest
 from great_expectations import __version__ as gx_version
@@ -95,3 +96,71 @@ def fake_subscriber(mocker) -> FakeSubscriber:
     subscriber = FakeSubscriber(client=object())
     mocker.patch("great_expectations_cloud.agent.agent.Subscriber", return_value=subscriber)
     return subscriber
+
+
+class DataContextConfigTD(TypedDict):
+    anonymous_usage_statistics: dict
+    checkpoint_store_name: str
+    datasources: dict
+    stores: dict
+
+
+@pytest.fixture
+def data_context_config() -> DataContextConfigTD:
+    """
+    Return a minimal DataContext config for testing.
+    This what GET /organizations/{id}/data-contexts/{id} should return.
+
+    See also:
+    https://github.com/great-expectations/great_expectations/blob/develop/tests/datasource/fluent/_fake_cloud_api.py
+    """
+    return {
+        "anonymous_usage_statistics": {
+            "data_context_id": str(uuid.uuid4()),
+            "enabled": False,
+        },
+        "checkpoint_store_name": "default_checkpoint_store",
+        "datasources": {},
+        "stores": {
+            "default_evaluation_parameter_store": {"class_name": "EvaluationParameterStore"},
+            "default_expectations_store": {
+                "class_name": "ExpectationsStore",
+                "store_backend": {
+                    "class_name": "GXCloudStoreBackend",
+                    "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
+                    "ge_cloud_credentials": {
+                        "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
+                        "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
+                    },
+                    "ge_cloud_resource_type": "expectation_suite",
+                    "suppress_store_backend_id": True,
+                },
+            },
+            "default_checkpoint_store": {
+                "class_name": "CheckpointStore",
+                "store_backend": {
+                    "class_name": "GXCloudStoreBackend",
+                    "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
+                    "ge_cloud_credentials": {
+                        "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
+                        "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
+                    },
+                    "ge_cloud_resource_type": "checkpoint",
+                    "suppress_store_backend_id": True,
+                },
+            },
+            "default_validations_store": {
+                "class_name": "ValidationsStore",
+                "store_backend": {
+                    "class_name": "GXCloudStoreBackend",
+                    "ge_cloud_base_url": r"${GX_CLOUD_BASE_URL}",
+                    "ge_cloud_credentials": {
+                        "access_token": r"${GX_CLOUD_ACCESS_TOKEN}",
+                        "organization_id": r"${GX_CLOUD_ORGANIZATION_ID}",
+                    },
+                    "ge_cloud_resource_type": "validation_result",
+                    "suppress_store_backend_id": True,
+                },
+            },
+        },
+    }

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -284,7 +284,7 @@ def test_correlation_id_header(
     agent_job_ids: list[str] = [str(uuid.uuid4()) for _ in range(3)]
     datasource_config_id_1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
     datasource_config_id_2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
-    checkpoint_id = uuid.UUID("00000000-0000-0000-0003-000000000000")
+    checkpoint_id = uuid.UUID("00000000-0000-0000-0000-000000000003")
     # seed the fake queue with an event that will be consumed by the agent
     fake_subscriber.test_queue.extendleft(
         [
@@ -325,7 +325,7 @@ def test_correlation_id_header(
                 responses.matchers.header_matcher(
                     {
                         HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{GXAgent._get_current_gx_agent_version()}",  # TODO: remove
-                        # HeaderName.AGENT_JOB_ID: agent_job_ids[2],  # TODO: uncomment
+                        HeaderName.AGENT_JOB_ID: agent_job_ids[2],
                     }
                 )
             ],

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -340,14 +340,7 @@ def test_correlation_id_header(
             f"{base_url}organizations/{org_id}/checkpoints/{checkpoint_id}",
             json={"data": {}},
             # match will fail if correlation-id header is not set
-            match=[
-                responses.matchers.header_matcher(
-                    {
-                        HeaderName.USER_AGENT: f"{USER_AGENT_HEADER}/{GXAgent._get_current_gx_agent_version()}",  # TODO: remove
-                        HeaderName.AGENT_JOB_ID: agent_job_ids[2],
-                    }
-                )
-            ],
+            match=[responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: agent_job_ids[2]})],
         )
         agent = GXAgent()
         agent.run()

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -281,7 +281,7 @@ def ds_config_factory() -> Callable[[str], dict[Literal["name", "type", "connect
     But will fail if trying to add a TableAsset because no tables exist for it.
     """
 
-    def _factory(name: str) -> dict[Literal["name", "type", "connection_string"], str]:
+    def _factory(name: str = "test-ds") -> dict[Literal["name", "type", "connection_string"], str]:
         return {
             "name": name,
             "type": "sqlite",


### PR DESCRIPTION
The `AgentJobId` header was not being set for the `RunCheckpointEvent`/`RunCheckpointAction` but is for other events like `DraftDatasourceConfigEvent `

- Initial implementation https://github.com/great-expectations/cloud/pull/97

This will ensure that `Agent-Job-Id` is set for any GX Cloud API call that originates from core OSS code.

### Notes

`_set_http_session_headers()` is modifying global state (it's monkeypatching a method in the OSS code), and can be called with or without a `correlation_id`.
https://github.com/great-expectations/cloud/blob/a3fee2fbcd5c041a66ebbfbf3e545450cc49ed6c/great_expectations_cloud/agent/agent.py#L166-L167

~My initial guess was that `_set_http_session_headers()` was being called without the `correlation_id` and this was causing the `Agent-Job-Id` to be unset, but after adding more logging this doesn't appear to be the case. `_set_http_session_headers()` is only called once without a `correlation_id` when the agent is first setting up the context, after that it always has a `correlation_id` provided.~

The issue was that the stores use a different session that is created before we have a `correlation_id`.
The fix is to update `_set_http_session_headers()` to apply the `correlation_id`/`Agent-Job-Id` header to each `GXCloudStoreBackend` session.

https://github.com/great-expectations/great_expectations/blob/91240de2862a33b7e7016c274b31e6693405cc78/great_expectations/data_context/store/gx_cloud_store_backend.py#L207-L209

`DraftDatasourceConfigEvent` is not using a `GXCloudStoreBackend` to make these HTTP calls and so didn't suffer from this problem.