### PR TITLE
fix release failure: remove redundant command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,3 @@ COPY examples/agent/data data
 RUN poetry install --only-root && rm -rf POETRY_CACHE_DIR
 
 ENTRYPOINT ["poetry", "run", "gx-agent"]
-CMD ["poetry", "run", "gx-agent"]


### PR DESCRIPTION
fix release failure: remove redundant command

CMD failing when in docker compose

Verified fix locally as:
- docker run
- docker compose