### PR TITLE
Update event models to allow extra properties to ensure backwards compatibility

### DIFF
--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -10,7 +10,7 @@ from typing_extensions import Annotated
 
 class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
     class Config:
-        extra: str = Extra.allow
+        extra: str = Extra.ignore
 
 
 class EventBase(AgentBaseModel):

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -10,7 +10,7 @@ from typing_extensions import Annotated
 
 class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
     class Config:
-        extra: str = Extra.forbid
+        extra: str = Extra.allow
 
 
 class EventBase(AgentBaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.28"
+version = "0.0.29"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.29"
+version = "0.0.30"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
In #127, we are adding a property to an existing Event model. This change will be merged to both `mercury` and `cloud`, but we currently don't allow for extra properties on event models...so if #127 is merged and users do not immediately upgrade their GX Agent version, the RunCheckpointEvent type is not recognized and therefore cannot be processed, which breaks running checkpoints/validations.

To ensure backwards compatibility, we need to make sure that the Agent code can recognize events even if they have additional properties; hence this change.

I'm open to doing this another way if there are suggestions.
