### PR TITLE
Stricter Generics Typing

### DIFF
--- a/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
+++ b/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
 from great_expectations.compatibility import pydantic
@@ -35,7 +36,7 @@ class DraftDatasourceConfigAction(AgentAction[DraftDatasourceConfigEvent]):
         datasource.test_connection(test_assets=True)  # raises `TestConnectionError` on failure
         return ActionResult(id=id, type=event.type, created_resources=[])
 
-    def get_draft_config(self, config_id: UUID) -> dict:
+    def get_draft_config(self, config_id: UUID) -> dict[str, Any]:
         try:
             config = GxAgentEnvVars()
         except pydantic.ValidationError as validation_err:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -9,7 +9,7 @@ from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
 from importlib.metadata import version as metadata_version
-from typing import TYPE_CHECKING, Dict, Final
+from typing import TYPE_CHECKING, Any, Dict, Final
 
 from great_expectations import get_context
 from great_expectations.compatibility import pydantic
@@ -104,8 +104,8 @@ class GXAgent:
         # the CloudDataContext cached here is used by the worker, so
         # it isn't safe to increase the number of workers running GX jobs.
         self._executor = ThreadPoolExecutor(max_workers=1)
-        self._current_task: Future | None = None
-        self._correlation_ids: defaultdict = defaultdict(lambda: 0)
+        self._current_task: Future[Any] | None = None
+        self._correlation_ids: defaultdict[str, int] = defaultdict(lambda: 0)
 
     def run(self) -> None:
         """Open a connection to GX Cloud."""
@@ -196,7 +196,9 @@ class GXAgent:
         result = handler.handle_event(event=event_context.event, id=event_context.correlation_id)
         return result
 
-    def _handle_event_as_thread_exit(self, future: Future, event_context: EventContext) -> None:
+    def _handle_event_as_thread_exit(
+        self, future: Future[ActionResult], event_context: EventContext
+    ) -> None:
         """Callback invoked when the thread running GX exits.
 
         Args:

--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from great_expectations.experimental.metric_repository.batch_inspector import (
     BatchInspector,
@@ -58,7 +58,7 @@ class EventHandler:
     def __init__(self, context: CloudDataContext) -> None:
         self._context = context
 
-    def get_event_action(self, event: Event) -> AgentAction:
+    def get_event_action(self, event: Event) -> AgentAction[Any]:
         """Get the action that should be run for the given event."""
         if isinstance(event, RunOnboardingDataAssistantEvent):
             return RunOnboardingDataAssistantAction(context=self._context)

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -22,7 +22,12 @@ class OnMessagePayload:
     body: bytes
 
 
-class OnMessageCallback(Protocol):
+class OnMessageFn(Protocol):
+    """
+    Callback invoked when a message is received.
+    Accepts a single argument, a payload object and returns None.
+    """
+
     def __call__(self, payload: OnMessagePayload) -> None:
         ...
 
@@ -40,7 +45,7 @@ class AsyncRabbitMQClient:
         self._consumer_tag = None
         self._consuming = False
 
-    def run(self, queue: str, on_message: OnMessageCallback) -> None:
+    def run(self, queue: str, on_message: OnMessageFn) -> None:
         """Run an async connection to RabbitMQ.
 
         Args:
@@ -150,7 +155,7 @@ class AsyncRabbitMQClient:
         method_frame: Basic.Deliver,
         header_frame: BasicProperties,
         body: bytes,
-        on_message: OnMessageCallback,
+        on_message: OnMessageFn,
     ) -> None:
         """Called by Pika when a message is received."""
         # param on_message is provided by the caller as an argument to AsyncRabbitMQClient.run
@@ -161,7 +166,7 @@ class AsyncRabbitMQClient:
         )
         return on_message(payload)
 
-    def _start_consuming(self, queue: str, on_message: OnMessageCallback, channel: Channel) -> None:
+    def _start_consuming(self, queue: str, on_message: OnMessageFn, channel: Channel) -> None:
         """Consume from a channel with the on_message callback."""
         channel.add_on_cancel_callback(self._on_consumer_canceled)
         self._consumer_tag = channel.basic_consume(queue=queue, on_message_callback=on_message)
@@ -188,7 +193,7 @@ class AsyncRabbitMQClient:
             self._channel.close()
 
     def _on_connection_open(
-        self, connection: AsyncioConnection, queue: str, on_message: OnMessageCallback
+        self, connection: AsyncioConnection, queue: str, on_message: OnMessageFn
     ) -> None:
         """Callback invoked after the broker opens the connection."""
         on_channel_open = partial(self._on_channel_open, queue=queue, on_message=on_message)
@@ -214,7 +219,7 @@ class AsyncRabbitMQClient:
         else:
             self._connection.close()
 
-    def _on_channel_open(self, channel: Channel, queue: str, on_message: OnMessageCallback) -> None:
+    def _on_channel_open(self, channel: Channel, queue: str, on_message: OnMessageFn) -> None:
         """Callback invoked after the broker opens the channel."""
         self._channel = channel
         channel.add_on_close_callback(self._on_channel_closed)

--- a/great_expectations_cloud/agent/message_service/subscriber.py
+++ b/great_expectations_cloud/agent/message_service/subscriber.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass
 from functools import partial
 from json import JSONDecodeError
-from typing import TYPE_CHECKING, Callable, Coroutine
+from typing import TYPE_CHECKING, Callable, Coroutine, Protocol
 
 from great_expectations.compatibility import pydantic
 from pika.exceptions import (
@@ -42,10 +42,14 @@ class EventContext:
     correlation_id: str
     processed_successfully: Callable[[], None]
     processed_with_failures: Callable[[], None]
-    redeliver_message: Callable[[], Coroutine]
+    redeliver_message: Callable[[], Coroutine[OnMessageCallback, None, None]]
 
 
-OnMessageCallback = Callable[[EventContext], None]
+class OnMessageCallback(Protocol):
+    """Callback for handling incoming messages."""
+
+    def __call__(self, event_context: EventContext) -> None:
+        """Handle an incoming message."""
 
 
 class Subscriber:

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Literal, Optional, Sequence, Union
+from typing import Any, Literal, Optional, Sequence, Union
 from uuid import UUID
 
 from great_expectations.compatibility.pydantic import BaseModel, Extra, Field
@@ -39,7 +39,7 @@ class RunMissingnessDataAssistantEvent(RunDataAssistantEvent):
 class RunCheckpointEvent(EventBase):
     type: Literal["run_checkpoint_request"] = "run_checkpoint_request"
     checkpoint_id: uuid.UUID
-    splitter_options: Optional[dict] = None
+    splitter_options: Optional[dict[str, Any]] = None
 
 
 class RunColumnDescriptiveMetricsEvent(EventBase):

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Literal, Optional, Sequence, Union
+from typing import Any, Dict, Literal, Optional, Sequence, Union
 from uuid import UUID
 
 from great_expectations.compatibility.pydantic import BaseModel, Extra, Field
@@ -39,7 +39,7 @@ class RunMissingnessDataAssistantEvent(RunDataAssistantEvent):
 class RunCheckpointEvent(EventBase):
     type: Literal["run_checkpoint_request"] = "run_checkpoint_request"
     checkpoint_id: uuid.UUID
-    splitter_options: Optional[dict[str, Any]] = None
+    splitter_options: Optional[Dict[str, Any]] = None
 
 
 class RunColumnDescriptiveMetricsEvent(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ follow_imports = 'normal'
 warn_redundant_casts = true
 show_error_codes = true
 implicit_reexport = true                                         # enabled due to strict mode
-disallow_any_generics = false                                    # consider enabling
 enable_error_code = ['ignore-without-code', 'explicit-override']
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,9 @@ max-complexity = 10
     "F403", # star imports
 ]
 "models.py" = [
+    # TODO: remove these once our min python is 3.9 or greater
+    # or once these rule respect runtime-evaluated-base-classes
+    "UP006", # non-pep585-annotation - pydantic models use annotations at runtime
     "UP007", # non-pep604-annotation - pydantic models use annotations at runtime
 ]
 "tasks.py" = [

--- a/tasks.py
+++ b/tasks.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import pathlib
 from pprint import pformat as pf
-from typing import TYPE_CHECKING, Final, Literal, MutableMapping
+from typing import TYPE_CHECKING, Any, Final, Literal, MutableMapping
 
 import invoke
 import requests
@@ -25,7 +25,7 @@ DOCKERFILE_PATH: Final[str] = "./Dockerfile"
 @functools.lru_cache(maxsize=8)
 def _get_pyproject_tool_dict(
     tool_key: Literal["poetry", "black", "ruff", "mypy"] | None = None,
-) -> MutableMapping:
+) -> MutableMapping[str, Any]:
     """
     Load the pyproject.toml file as a dict. Optional return the config of a specific tool.
     Caches each tool's config for faster access.

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -44,7 +44,9 @@ def set_required_env_vars(monkeypatch, org_id, token) -> None:
         monkeypatch.setenv(name=key, value=val)
 
 
-def build_payload(config: dict, id: UUID) -> dict:
+def build_payload(
+    config: dict[str, Any], id: UUID
+) -> dict[Literal["data"], dict[str, str | UUID | dict[str, Any]]]:
     return {
         "data": {
             "type": "draft_config",

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -99,10 +99,10 @@ def fake_subscriber(mocker) -> FakeSubscriber:
 
 
 class DataContextConfigTD(TypedDict):
-    anonymous_usage_statistics: dict
+    anonymous_usage_statistics: dict[str, Any]
     checkpoint_store_name: str
-    datasources: dict
-    stores: dict
+    datasources: dict[str, dict[str, Any]]
+    stores: dict[str, dict[str, Any]]
 
 
 @pytest.fixture

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import warnings
 from pprint import pformat as pf
-from typing import Final, Mapping
+from typing import Any, Final, Mapping
 
 import pytest
 import tomlkit
@@ -40,7 +40,7 @@ def test_great_expectations_is_installed(min_gx_version):
 
 
 @pytest.fixture
-def pre_commit_config_repos() -> Mapping[str, dict]:
+def pre_commit_config_repos() -> Mapping[str, dict[str, Any]]:
     """
     Extract the repos from the pre-commit config file and return a dict with the
     repo source url as the key
@@ -52,16 +52,17 @@ def pre_commit_config_repos() -> Mapping[str, dict]:
 
 
 @pytest.fixture
-def poetry_lock_packages() -> Mapping[str, dict]:
+def poetry_lock_packages() -> Mapping[str, dict[str, Any]]:
     poetry_lock = PROJECT_ROOT / "poetry.lock"
     toml_doc = tomlkit.loads(poetry_lock.read_text())
     LOGGER.info(f"poetry.lock ->\n {pf(toml_doc, depth=1)[:1000]}...")
-    packages: list[dict] = toml_doc["package"].unwrap()  # type: ignore[assignment] # values are always list[dict]
+    packages: list[dict[str, Any]] = toml_doc["package"].unwrap()  # type: ignore[assignment] # values are always list[dict]
     return {pkg.pop("name"): pkg for pkg in packages}
 
 
 def test_pre_commit_versions_are_in_sync(
-    pre_commit_config_repos: Mapping, poetry_lock_packages: Mapping
+    pre_commit_config_repos: Mapping[str, dict[str, Any]],
+    poetry_lock_packages: Mapping[str, dict[str, Any]],
 ):
     repo_package_lookup = {
         "https://github.com/astral-sh/ruff-pre-commit": "ruff",


### PR DESCRIPTION
Require that generics specify a type.
This is part of the default `mypy` `strict` mode.
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-disallow-any-generics

```
x: list # this is no longer allowed

x: list[str] # allowed
x: list[typing.Any] # also allowed but should generally be discouraged

x: typing.List[str] # required for pydantic models that use annotations at runtime
```