### PR TITLE
ZEL-503: Only test connection for profiled data asset

### DIFF
--- a/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
@@ -35,8 +35,9 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
     @override
     def run(self, event: RunColumnDescriptiveMetricsEvent, id: str) -> ActionResult:
         datasource = self._context.get_datasource(event.datasource_name)
-        datasource.test_connection(test_assets=True)  # raises `TestConnectionError` on failure
         data_asset = datasource.get_asset(event.data_asset_name)
+        data_asset.test_connection()  # raises `TestConnectionError` on failure
+
         batch_request = data_asset.build_batch_request()
 
         metric_run = self._batch_inspector.compute_metric_run(

--- a/tests/agent/actions/test_run_column_descriptive_metrics_action.py
+++ b/tests/agent/actions/test_run_column_descriptive_metrics_action.py
@@ -111,7 +111,7 @@ def test_run_column_descriptive_metrics_returns_action_result():
     ]
 
 
-def test_run_column_descriptive_metrics_raises_on_test_connection_failure():
+def test_run_column_descriptive_metrics_raises_on_test_connection_to_datasource_failure():
     mock_context = Mock(spec=CloudDataContext)
     mock_metric_repository = Mock(spec=MetricRepository)
     mock_batch_inspector = Mock(spec=BatchInspector)
@@ -119,6 +119,36 @@ def test_run_column_descriptive_metrics_raises_on_test_connection_failure():
     mock_datasource = Mock()
     mock_context.get_datasource.return_value = mock_datasource
     mock_datasource.test_connection.side_effect = TestConnectionError()
+
+    action = ColumnDescriptiveMetricsAction(
+        context=mock_context,
+        metric_repository=mock_metric_repository,
+        batch_inspector=mock_batch_inspector,
+    )
+
+    with pytest.raises(TestConnectionError):
+        action.run(
+            event=RunColumnDescriptiveMetricsEvent(
+                type="column_descriptive_metrics_request.received",
+                datasource_name="test-datasource",
+                data_asset_name="test-data-asset",
+            ),
+            id="test-id",
+        )
+
+    mock_batch_inspector.compute_metric_run.assert_not_called()
+
+
+def test_run_column_descriptive_metrics_raises_on_test_connection_to_data_asset_failure():
+    mock_context = Mock(spec=CloudDataContext)
+    mock_metric_repository = Mock(spec=MetricRepository)
+    mock_batch_inspector = Mock(spec=BatchInspector)
+
+    mock_datasource = Mock()
+    mock_context.get_datasource.return_value = mock_datasource
+    mock_data_asset = Mock()
+    mock_datasource.get_asset.return_value = mock_data_asset
+    mock_data_asset.test_connection.side_effect = TestConnectionError()
 
     action = ColumnDescriptiveMetricsAction(
         context=mock_context,


### PR DESCRIPTION
We've been testing the connection for all of the data assets in a datasource. When users run CDM, we only need to test the connection for the data asset that is being profiled.

With the changes in this PR, here is what the error messages look like for a nonexistent table and a Data Source with bad creds:

![image](https://github.com/great-expectations/cloud/assets/32279443/0a2e0ce8-9fb2-4bc7-99a1-d0b648d68a85)
