### PR TITLE
Refactor CDM action

### DIFF
--- a/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
@@ -24,9 +24,6 @@ from great_expectations_cloud.agent.models import (
 
 if TYPE_CHECKING:
     from great_expectations.data_context import CloudDataContext
-    from great_expectations.experimental.metric_repository.metric_retriever import (
-        MetricRetriever,
-    )
     from great_expectations.experimental.metric_repository.metrics import MetricRun
 
 
@@ -38,12 +35,12 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
         batch_inspector: BatchInspector | None = None,
     ):
         super().__init__(context=context)
-        metric_retrievers: list[MetricRetriever] = [
-            ColumnDescriptiveMetricsMetricRetriever(self._context)
-        ]
-        cloud_data_store = CloudDataStore(self._context)
-        self._metric_repository = metric_repository or MetricRepository(data_store=cloud_data_store)
-        self._batch_inspector = batch_inspector or BatchInspector(context, metric_retrievers)
+        self._metric_repository = metric_repository or MetricRepository(
+            data_store=CloudDataStore(self._context)
+        )
+        self._batch_inspector = batch_inspector or BatchInspector(
+            context, ColumnDescriptiveMetricsMetricRetriever(self._context)
+        )
 
     @override
     def run(self, event: RunColumnDescriptiveMetricsEvent, id: str) -> ActionResult:

--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -3,19 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
-from great_expectations.experimental.metric_repository.batch_inspector import (
-    BatchInspector,
-)
-from great_expectations.experimental.metric_repository.cloud_data_store import (
-    CloudDataStore,
-)
-from great_expectations.experimental.metric_repository.column_descriptive_metrics_metric_retriever import (
-    ColumnDescriptiveMetricsMetricRetriever,
-)
-from great_expectations.experimental.metric_repository.metric_repository import (
-    MetricRepository,
-)
-
 from great_expectations_cloud.agent.actions import (
     ColumnDescriptiveMetricsAction,
     ListTableNamesAction,
@@ -40,9 +27,6 @@ from great_expectations_cloud.agent.models import (
 
 if TYPE_CHECKING:
     from great_expectations.data_context import CloudDataContext
-    from great_expectations.experimental.metric_repository.metric_retriever import (
-        MetricRetriever,
-    )
 
     from great_expectations_cloud.agent.actions.agent_action import ActionResult, AgentAction
 
@@ -73,17 +57,7 @@ class EventHandler:
             return RunCheckpointAction(context=self._context)
 
         if isinstance(event, RunColumnDescriptiveMetricsEvent):
-            metric_retrievers: list[MetricRetriever] = [
-                ColumnDescriptiveMetricsMetricRetriever(self._context)
-            ]
-            batch_inspector = BatchInspector(self._context, metric_retrievers)
-            cloud_data_store = CloudDataStore(self._context)
-            column_descriptive_metrics_repository = MetricRepository(data_store=cloud_data_store)
-            return ColumnDescriptiveMetricsAction(
-                context=self._context,
-                batch_inspector=batch_inspector,
-                metric_repository=column_descriptive_metrics_repository,
-            )
+            return ColumnDescriptiveMetricsAction(context=self._context)
 
         if isinstance(event, DraftDatasourceConfigEvent):
             return DraftDatasourceConfigAction(context=self._context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.36"
+version = "0.0.37.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Refactor the CDM action to match the signature of the parent action (context-only init). Provide defaults for the existing params.
Dev release since this is only a refactor that does not change functionality.

Thanks @billdirks for the catch!