### PR TITLE
ZEL-535: Fix CDM error - pass metrics retriever as a list to avoid iterable error

### DIFF
--- a/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations_cloud/agent/actions/run_column_descriptive_metrics_action.py
@@ -39,7 +39,7 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
             data_store=CloudDataStore(self._context)
         )
         self._batch_inspector = batch_inspector or BatchInspector(
-            context, ColumnDescriptiveMetricsMetricRetriever(self._context)
+            context, [ColumnDescriptiveMetricsMetricRetriever(self._context)]
         )
 
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "0.0.37.dev0"
+version = "0.0.38"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Issue:

Running CDM was returning `'ColumnDescriptiveMetricsMetricRetriever' object is not iterable` error after changes in #149 

Solution:

The BatchInspector constructor expects a list of `MetricRetriever` - pass in a list instead