### PR TITLE
Codecov flags config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,10 +145,11 @@ jobs:
 
       # upload coverage report to codecov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: great-expectations/cloud
+          flags: ${{ matrix.python-version }}
 
   coveralls:
     name: Upload to coveralls.io

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -115,3 +115,14 @@ jobs:
       - name: Show logs, if failure
         if: failure()
         run: docker compose logs
+
+      # NOTE: can't use coveralls here without refactoring workflows
+
+      # upload coverage report to codecov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: great-expectations/cloud
+          # use the same flags as the test markers
+          flags: agentjobs

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,12 +6,12 @@ flag_management:
         target: auto # the default target for the project
         threshold: 2% # the minimum coverage required to pass the project
       - type: patch
-        target: 85%
+        target: 90%
   # in general these individual flags should correspond to pytest markers
   individual_flags: # exceptions to the default rules above, stated flag by flag
     - name: agentjobs
       statuses:
         - type: project
-          target: 70%
+          target: 45%
         - type: patch
-          target: 90%
+          target: 70%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,18 +1,17 @@
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true
+    carryforward: false
     statuses:
       - type: project
         target: auto # the default target for the project
         threshold: 2% # the minimum coverage required to pass the project
       - type: patch
-        target: 90%
+        target: 85%
   # in general these individual flags should correspond to pytest markers
   individual_flags: # exceptions to the default rules above, stated flag by flag
     - name: agentjobs
-      carryforward: true
       statuses:
         - type: project
-          target: 80%
+          target: 70%
         - type: patch
-          target: 95%
+          target: 90%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto # the default target for the project
+        threshold: 2% # the minimum coverage required to pass the project
+      - type: patch
+        target: 90%
+  # in general these individual flags should correspond to pytest markers
+  individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: agentjobs
+      carryforward: true
+      statuses:
+        - type: project
+          target: 80%
+        - type: patch
+          target: 95%

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ flag_management:
     statuses:
       - type: project
         target: auto # the default target for the project
-        threshold: 2% # the minimum coverage required to pass the project
+        threshold: 70% # the default minimum threshold for the project
       - type: patch
         target: 90%
   # in general these individual flags should correspond to pytest markers

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -156,9 +156,7 @@ class TestCoverageSettings:
         """
         pytest_markers: Iterable[str] = tomlkit.loads(PYPROJECT_TOML.read_text())["tool"]["pytest"][  # type: ignore[index,assignment]
             "ini_options"
-        ][
-            "markers"
-        ]
+        ]["markers"]
         codecov_dict = yaml.load(CODECOV_YML.read_text())
 
         invalid_flags: set[str] = set()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -154,9 +154,11 @@ class TestCoverageSettings:
         This test ensures the codecov.yml flags are valid pytest markers from the pyproject.toml file.
         The python versions flags are an exception here 3.8, 3.10, etc. do not need to pytest markers.
         """
-        pytest_markers: Iterable[str] = tomlkit.loads(PYPROJECT_TOML.read_text())["tool"]["pytest"][  # type: ignore[index,assignment] # always
+        pytest_markers: Iterable[str] = tomlkit.loads(PYPROJECT_TOML.read_text())["tool"]["pytest"][  # type: ignore[index,assignment]
             "ini_options"
-        ]["markers"]
+        ][
+            "markers"
+        ]
         codecov_dict = yaml.load(CODECOV_YML.read_text())
 
         invalid_flags: set[str] = set()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import warnings
 from pprint import pformat as pf
-from typing import Any, Final, Mapping, Sequence
+from typing import Any, Final, Iterable, Mapping
 
 import pytest
 import tomlkit
@@ -154,7 +154,7 @@ class TestCoverageSettings:
         This test ensures the codecov.yml flags are valid pytest markers from the pyproject.toml file.
         The python versions flags are an exception here 3.8, 3.10, etc. do not need to pytest markers.
         """
-        pytest_markers: Sequence[str] = tomlkit.loads(PYPROJECT_TOML.read_text())["tool"]["pytest"][
+        pytest_markers: Iterable[str] = tomlkit.loads(PYPROJECT_TOML.read_text())["tool"]["pytest"][  # type: ignore[index,assignment] # always
             "ini_options"
         ]["markers"]
         codecov_dict = yaml.load(CODECOV_YML.read_text())


### PR DESCRIPTION
Add `codecov.yml` file to take advantage of additional `flag` features.

>Here are just a few features unlocked by adding Flag definitions to your YAML.

1. Flags in [PR Comments](https://docs.codecov.com/docs/pull-request-comments) and [Status Checks](https://docs.codecov.com/docs/commit-status) in your Github, Gitlab, Bitbucket instance
2. Overlay [source code coverage in UI](https://docs.codecov.com/docs/viewing-source-code) by Flag
3. [Carryforward Flags](https://docs.codecov.com/docs/carryforward-flags) for partial test runs
Etc.

https://docs.codecov.com/docs/flags#step-2-flag-management-in-yaml

This is being used as part of an evaluation between coveralls + codecov