### PR TITLE
Force version bump on poetry.lock change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
           filters: |
             agent:
               - 'great_expectations_cloud/agent/**'
+              - 'poetry.lock'
 
   check-version-is-bumped:
     # This job checks that the version in the PR is different from the version in main if the agent has changed.


### PR DESCRIPTION
Make sure we bump the agent version via CI check when bumping dependencies e.g. GX version in `poetry.lock`.