### PR TITLE
Z2-296: Add stable tag to dockerhub

### DIFF
--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -64,7 +64,9 @@ jobs:
           platforms: linux/arm64
           push: false
           load: false
-          tags: greatexpectations/agent:latest
+          tags: |
+            greatexpectations/agent:latest
+            greatexpectations/agent:stable
 
       # https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Build amd64, With Load, No Push
@@ -74,10 +76,12 @@ jobs:
           platforms: linux/amd64
           push: false
           load: true
-          tags: greatexpectations/agent:latest
+          tags: |
+            greatexpectations/agent:latest
+            greatexpectations/agent:stable
 
       - name: Smoke Test the Image
-        run: docker run --rm greatexpectations/agent:latest poetry run gx-agent -h
+        run: docker run --rm greatexpectations/agent:stable poetry run gx-agent -h
 
       # Uses local image built in previous step
       - name: Test New amd64 Agent Image
@@ -129,6 +133,7 @@ jobs:
           tags: |
             greatexpectations/agent:${{ steps.get_version.outputs.POETRY_VERSION }}
             greatexpectations/agent:latest
+            greatexpectations/agent:stable
             258143015559.dkr.ecr.us-east-1.amazonaws.com/gx/agent:${{ steps.get_version.outputs.POETRY_VERSION }}
 
       - name: Show logs, if failure


### PR DESCRIPTION
Add `stable` tag to agent image that is pushed to dockerhub.

(Note: we are keeping the `latest` tag for now.)