### PR TITLE
Fix `invoke pre-release` ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
         run: gh pr checkout ${{ github.event.pull_request.number }}
 
       - name: Bump pre-release version
-        run: invoke pre-release
+        run: poetry run invoke pre-release
 
       - name: Push changes to PR
         env:


### PR DESCRIPTION
`invoke` needs to be run from within the virtual env.

What we should probably do is update our CI usage of poetry to not use a virtual env and install packages directly to the runner env.