### PR TITLE
Update dependabot to run daily instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
   - package-ecosystem: "pip" # Documentation: For package managers such as pipenv and poetry, you need to use the pip YAML value.
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Updating dependabot to run daily instead of weekly as discussed here: https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1712930265826609

(Add'l changes for Z2-300 to come in a separate PR)