### PR TITLE
Add check-no-version-bump-label job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,8 +273,10 @@ jobs:
         id: check_no_version_bump_label_exists
         run: |
           if [[ "${{ steps.get_pr_labels.outputs.LABELS }}" == *"no version bump"* ]]; then
+            echo "Setting NO_VERSION_BUMP_LABEL to true"
             echo "NO_VERSION_BUMP_LABEL=true" >> $GITHUB_OUTPUT
           else
+            echo "Setting NO_VERSION_BUMP_LABEL to false"
             echo "NO_VERSION_BUMP_LABEL=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'schedule' }}
     outputs:
-      check_no_version_bump_label: ${{ steps.check_no_version_bump_label.outputs.NO_VERSION_BUMP_LABEL }}
+      check_no_version_bump_label_exists: ${{ steps.check_no_version_bump_label_exists.outputs.NO_VERSION_BUMP_LABEL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -270,7 +270,7 @@ jobs:
         id: get_pr_labels
         run: echo "LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')" >> $GITHUB_OUTPUT
       - name: Check if PR has "no version bump" label
-        id: check_no_version_bump_label
+        id: check_no_version_bump_label_exists
         run: |
           if [[ "${{ steps.get_pr_labels.outputs.LABELS }}" == *"no version bump"* ]]; then
             echo "NO_VERSION_BUMP_LABEL=true" >> $GITHUB_OUTPUT
@@ -283,7 +283,7 @@ jobs:
       contents: write # Allow us to write to the repository
     needs: [check-version-is-bumped, check-no-version-bump-label]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && needs.check-no-version-bump-label.outputs.check_no_version_bump_label && github.event_name != 'schedule' }}
+    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && needs.check-no-version-bump-label.outputs.check_no_version_bump_label_exists == 'false' && github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
 
   check-if-agent-changed:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'schedule' }}
+    if: ${{ github.event_name != 'schedule' && !contains(github.event.pull_request.labels.*.name, 'no version bump') }}
     outputs:
       agent_changed: ${{ steps.filter.outputs.agent }}
     steps:
@@ -211,7 +211,7 @@ jobs:
     # This job checks that the version in the PR is different from the version in main if the agent has changed.
     needs: check-if-agent-changed
     runs-on: ubuntu-latest
-    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'true' && github.event_name != 'schedule' }}
+    if: ${{ needs.check-if-agent-changed.outputs.agent_changed == 'true' && !contains(github.event.pull_request.labels.*.name, 'no version bump') && github.event_name != 'schedule' }}
     outputs:
       is_version_bumped: ${{ steps.is_version_bumped.outputs.IS_VERSION_BUMPED }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,12 +258,32 @@ jobs:
             echo "IS_VERSION_BUMPED=true" >> $GITHUB_OUTPUT
           fi
 
+  check-no-version-bump-label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
+    outputs:
+      check_no_version_bump_label: ${{ steps.check_no_version_bump_label.outputs.NO_VERSION_BUMP_LABEL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get PR labels
+        id: get_pr_labels
+        run: echo "LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')" >> $GITHUB_OUTPUT
+      - name: Check if PR has "no version bump" label
+        id: check_no_version_bump_label
+        run: |
+          if [[ "${{ steps.get_pr_labels.outputs.LABELS }}" == *"no version bump"* ]]; then
+            echo "NO_VERSION_BUMP_LABEL=true" >> $GITHUB_OUTPUT
+          else
+            echo "NO_VERSION_BUMP_LABEL=false" >> $GITHUB_OUTPUT
+          fi
+
   bump-pre-release-version:
     permissions:
       contents: write # Allow us to write to the repository
-    needs: check-version-is-bumped
+    needs: [check-version-is-bumped, check-no-version-bump-label]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && github.event_name != 'schedule' }}
+    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && needs.check-no-version-bump-label.outputs.check_no_version_bump_label && github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,7 @@ jobs:
       - name: Check if PR has "no version bump" label
         id: check_no_version_bump_label_exists
         run: |
+          echo "Labels: ${{ steps.get_pr_labels.outputs.LABELS }}"
           if [[ "${{ steps.get_pr_labels.outputs.LABELS }}" == *"no version bump"* ]]; then
             echo "Setting NO_VERSION_BUMP_LABEL to true"
             echo "NO_VERSION_BUMP_LABEL=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,35 +258,12 @@ jobs:
             echo "IS_VERSION_BUMPED=true" >> $GITHUB_OUTPUT
           fi
 
-  check-no-version-bump-label:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'schedule' }}
-    outputs:
-      check_no_version_bump_label_exists: ${{ steps.check_no_version_bump_label_exists.outputs.NO_VERSION_BUMP_LABEL }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Get PR labels
-        id: get_pr_labels
-        run: echo "LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')" >> $GITHUB_OUTPUT
-      - name: Check if PR has "no version bump" label
-        id: check_no_version_bump_label_exists
-        run: |
-          echo "Labels: ${{ steps.get_pr_labels.outputs.LABELS }}"
-          if [[ "${{ steps.get_pr_labels.outputs.LABELS }}" == *"no version bump"* ]]; then
-            echo "Setting NO_VERSION_BUMP_LABEL to true"
-            echo "NO_VERSION_BUMP_LABEL=true" >> $GITHUB_OUTPUT
-          else
-            echo "Setting NO_VERSION_BUMP_LABEL to false"
-            echo "NO_VERSION_BUMP_LABEL=false" >> $GITHUB_OUTPUT
-          fi
-
   bump-pre-release-version:
     permissions:
       contents: write # Allow us to write to the repository
-    needs: [check-version-is-bumped, check-no-version-bump-label]
+    needs: check-version-is-bumped
     runs-on: ubuntu-latest
-    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && needs.check-no-version-bump-label.outputs.check_no_version_bump_label_exists == 'false' && github.event_name != 'schedule' }}
+    if: ${{ needs.check-version-is-bumped.outputs.is_version_bumped == 'false' && !contains(github.event.pull_request.labels.*.name, 'no version bump') && github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -221,8 +221,11 @@ GitHub's Dependabot regularly checks our dependencies for vulnerabilty-based upd
 Dependabot may only update the `poetry.lock` file. If only changes to `poetry.lock` are made, this may be done in a pre-release.
 
 For changes to the `pyproject.toml` file:
-- If the version of a tool in the `[tool.poetry.group.dev.dependencies]` group is updated, this may be done in a pre-release.
+- If the version of a tool in the `[tool.poetry.group.dev.dependencies]` group is updated, this may be done without any version bump.
    -  While doing this, make sure any version references in the pre-commit config `.pre-commit-config.yaml` are kept in sync (e.g., ruff).
-- For other dependency updates, a new release should be orchestrated. This includes updates in the following sections:
+- For other dependency updates or package build metadata changes, a new release should be orchestrated. This includes updates in the following sections:
   - `[tool.poetry.dependencies]`
   - `[tool.poetry.group.*.dependencies]` where `*` is the name of the group (not including the `dev` group)
+- To stop the auto-version bump add the `no version bump` label to the PR. Use this when:
+  - Only modifying dev dependencies.
+  - Only modifying tests that do not change functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 ]
 
 #Testing check-no-version-bump-label
-#Testing check-no-version-bump-label x2
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240501.0.dev1"
+version = "20240501.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 
+#Testing check-no-version-bump-label
+
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 great-expectations = "^0.18.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 
 #Testing check-no-version-bump-label
+#Testing check-no-version-bump-label x2
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240501.0.dev0"
+version = "20240501.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 
-#Testing check-no-version-bump-label
-
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 great-expectations = "^0.18.13"


### PR DESCRIPTION
- Only run the version bump related jobs if the `no version bump` label is not set.
- Update README with instructions.

Test runs of this functionality are in this PR (image below).

- [65bc60c](https://github.com/great-expectations/cloud/pull/243/commits/65bc60c2d0e694c6aee9284a99850bf4a5e30b34) bumped the version as expected (current functionality) after commit [fd29407](https://github.com/great-expectations/cloud/pull/243/commits/fd29407174e27c7a7e633308a00b4714aa697fc1) which changed `pyproject.toml`, a file tracked for changes that require version bump.
- After adding the `no version bump` label, version is not bumped in commit [90b1861](https://github.com/great-expectations/cloud/pull/243/commits/90b18610220d344e35191f9f8d2c33657f536d5c) - the version bump related jobs are skipped. See the following skipped jobs (by clicking on the green check next to commit [0478c5a](https://github.com/great-expectations/cloud/pull/243/commits/0478c5a4d732cdb09ed29b51c87f55e3db400ae1)): 
<img width="667" alt="image" src="https://github.com/great-expectations/cloud/assets/9903066/06e1d2d3-f8d3-4e3e-a2b1-35216ebdb06b">


### Test runs
<img width="856" alt="image" src="https://github.com/great-expectations/cloud/assets/9903066/f0ac8151-7c03-4338-9cc7-d924875ee7e1">

