### PR TITLE
Send ID via created_resources

### DIFF
--- a/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
+++ b/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
@@ -15,7 +15,7 @@ from great_expectations_cloud.agent.config import (
 )
 from great_expectations_cloud.agent.event_handler import register_event_action
 from great_expectations_cloud.agent.exceptions import ErrorCode, raise_with_error_code
-from great_expectations_cloud.agent.models import DraftDatasourceConfigEvent
+from great_expectations_cloud.agent.models import CreatedResource, DraftDatasourceConfigEvent
 
 
 class DraftDatasourceConfigAction(AgentAction[DraftDatasourceConfigEvent]):
@@ -40,6 +40,10 @@ class DraftDatasourceConfigAction(AgentAction[DraftDatasourceConfigEvent]):
         self, event: DraftDatasourceConfigEvent, id: str
     ) -> ActionResult:
         draft_config = self.get_draft_config(config_id=event.config_id)
+        created_resource = CreatedResource(
+            resource_id=str(event.config_id),
+            type="DraftDatasourceConfig",
+        )
         datasource_type = draft_config.get("type", None)
         if datasource_type is None:
             raise TypeError(  # noqa: TRY003 # one off error
@@ -55,7 +59,7 @@ class DraftDatasourceConfigAction(AgentAction[DraftDatasourceConfigEvent]):
         datasource = datasource_cls(**draft_config)
         datasource._data_context = self._context
         datasource.test_connection(test_assets=True)  # raises `TestConnectionError` on failure
-        return ActionResult(id=id, type=event.type, created_resources=[])
+        return ActionResult(id=id, type=event.type, created_resources=[created_resource])
 
     def get_draft_config(self, config_id: UUID) -> dict[str, Any]:
         try:


### PR DESCRIPTION
This is the start of a PR for sending the ID of a draft datasource config along with the job as a CreatedResource. When we test the connection successfully, we write an entry containing the draft datasource config to the `draft_configs` table - this entry is referenced by the ID in the CreatedResource.

In other words, we can use this ID on the front end to pull the proposed datasource name from the draft config to show in the test datasource config agent job log.