### PR TITLE
Don't bump dependabot PRs with dependencies tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
 
   check-if-agent-changed:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'schedule' && !contains(github.event.pull_request.labels.*.name, 'no version bump') }}
+    if: ${{ github.event_name != 'schedule' && !contains(github.event.pull_request.labels.*.name, 'no version bump') && !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     outputs:
       agent_changed: ${{ steps.filter.outputs.agent }}
     steps:


### PR DESCRIPTION
When we auto-bump the version in a dependabot PR, that stops dependabot from being able to automatically update the PR if a newer version of the dependency is released, e.g.:

![image](https://github.com/great-expectations/cloud/assets/9903066/75a390cd-d197-481b-9811-7e96c9491a48)

Often dependabot PRs don't require a release ([instructions](https://github.com/great-expectations/cloud?tab=readme-ov-file#dependabot-and-releasespre-releases)), so this requires extra work to merge or close both the outdated dependabot PR and then the updated dependabot PR. Let's avoid by not auto-bumping the version on dependabot PRs using the tag dependabot uses itself to tag PRs: `dependencies`.