### PR TITLE
Add back GreatExpectations version log at Agent startup

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -160,6 +160,8 @@ class GXAgent:
         version: str = metadata_version(cls._PYPI_GX_AGENT_PACKAGE_NAME)
         return version
 
+
+
     @classmethod
     def _get_current_great_expectations_version(cls) -> str:
         version: str = metadata_version(cls._PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME)

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -89,7 +89,9 @@ class GXAgent:
 
     def __init__(self: Self):
         agent_version: str = self.get_current_gx_agent_version()
+        great_expectations_version: str = self._get_current_great_expectations_version()
         print(f"GX Agent version: {agent_version}")
+        print(f"Great Expectations version: {great_expectations_version}")
         print("Initializing the GX Agent.")
         self._set_http_session_headers()
         self._config = self._get_config()
@@ -156,6 +158,11 @@ class GXAgent:
     @classmethod
     def get_current_gx_agent_version(cls) -> str:
         version: str = metadata_version(cls._PYPI_GX_AGENT_PACKAGE_NAME)
+        return version
+
+    @classmethod
+    def _get_current_great_expectations_version(cls) -> str:
+        version: str = metadata_version(cls._PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME)
         return version
 
     def _handle_event_as_thread_enter(self, event_context: EventContext) -> None:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -160,8 +160,6 @@ class GXAgent:
         version: str = metadata_version(cls._PYPI_GX_AGENT_PACKAGE_NAME)
         return version
 
-
-
     @classmethod
     def _get_current_great_expectations_version(cls) -> str:
         version: str = metadata_version(cls._PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240604.0.dev4"
+version = "20240605.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
- Reverts great-expectations/cloud#220

Upcoming changes to `great_expectations` including `1.0` will introduce breaking changes where the version of great_expectations is of extra relevance.

The version of the GX Agent by itself has very little meaning to most users.