### PR TITLE
invoke release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240606.0.dev0"
+version = "20240611.0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
* No GX Core version update needed (there hasn't been a release in the past week)
* Didn't merge the dependabot PRs since pod Zelda is in an offsite
* Also we've been seeing some CI failures ([example](https://github.com/great-expectations/cloud/actions/runs/9407873378/job/26096782878?pr=292)) on some of those PRs; wondering if we will see them here, too... (update: no issues with this PR)