### PR TITLE
Update Pydantic Model - Ignore Extra fields for `EventBase` only

### DIFF
--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Dict, Extra, Literal, Optional, Sequence, Set, Union
+from typing import Any, Dict, Literal, Optional, Sequence, Set, Union
 from uuid import UUID
 
 from great_expectations.compatibility.pydantic import BaseModel, ConfigDict, Field
@@ -12,13 +12,12 @@ from great_expectations_cloud.agent.exceptions import GXCoreError
 
 
 class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
-    class Config:
-        # 2024-03-04: ZEL-501 Strictly enforce models for handling outdated APIs
-        extra: str = Extra.forbid
+    model_config = ConfigDict(extra="forbid")
 
 
 class EventBase(AgentBaseModel):
     type: str
+    # ignoring extra fields in Action messages
     model_config = ConfigDict(extra="ignore")
 
 

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -4,7 +4,7 @@ import uuid
 from typing import Any, Dict, Literal, Optional, Sequence, Set, Union
 from uuid import UUID
 
-from great_expectations.compatibility.pydantic import BaseModel, Extra, Field
+from great_expectations.compatibility.pydantic import BaseModel, ConfigDict, Field
 from great_expectations.experimental.metric_repository.metrics import MetricTypes
 from typing_extensions import Annotated
 
@@ -12,9 +12,7 @@ from great_expectations_cloud.agent.exceptions import GXCoreError
 
 
 class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
-    class Config:
-        # 2024-03-04: ZEL-501 Strictly enforce models for handling outdated APIs
-        extra: str = Extra.forbid
+    model_config = ConfigDict(extra="ignore")
 
 
 class EventBase(AgentBaseModel):

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Dict, Literal, Optional, Sequence, Set, Union
+from typing import Any, Dict, Extra, Literal, Optional, Sequence, Set, Union
 from uuid import UUID
 
 from great_expectations.compatibility.pydantic import BaseModel, ConfigDict, Field
@@ -12,11 +12,14 @@ from great_expectations_cloud.agent.exceptions import GXCoreError
 
 
 class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
-    model_config = ConfigDict(extra="ignore")
+    class Config:
+        # 2024-03-04: ZEL-501 Strictly enforce models for handling outdated APIs
+        extra: str = Extra.forbid
 
 
 class EventBase(AgentBaseModel):
     type: str
+    model_config = ConfigDict(extra="ignore")
 
 
 class ScheduledEventBase(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240704.0.dev0"
+version = "20240705.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240703.0"
+version = "20240704.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -201,13 +201,14 @@ class TestEventHandlerRegistry:
             _get_major_version("invalid_version")
 
 
-def test_parse_event_extra_field(example_event):
+def test_parse_event_extra_field_is_ignored(example_event):
     event_dict = example_event.dict()
     event_dict["new_field"] = "surprise!"
     serialized_bytes = json.dumps(dict(event_dict), indent=2).encode("utf-8")
     event = EventHandler.parse_event_from(serialized_bytes)
 
-    assert event.type == "unknown_event"
+    # Extra field is ignored, which allows request to still be received - ZELDA-770
+    assert event.type == "onboarding_data_assistant_request.received"
 
 
 def test_parse_event_missing_required_field(example_event):


### PR DESCRIPTION
* Followed pattern described [here](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra). 
```python
from pydantic import BaseModel, ConfigDict
class User(BaseModel):
    model_config = ConfigDict(extra='ignore')  

    name: str
``` 

* Model also defaults to `ignore` for extra fields, but there may be value in making this explicit