### PR TITLE
Pin SQLAlchemy 1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4110,4 +4110,4 @@ snowflake = ["snowflake-sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "518226611bb71ba4b69a493a89a88dd6ba81856e3f1b464298530ac16b2a1a1a"
+content-hash = "f4cc69c3d48d1842c3e3570d9e610359de4d365678e54910ece9d3fe58e104d2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4110,4 +4110,4 @@ snowflake = ["snowflake-sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "d09d5e9e0696f84aabc3b29c15abd625638c1e6058ac0fbaaa5c20058b6e6f46"
+content-hash = "518226611bb71ba4b69a493a89a88dd6ba81856e3f1b464298530ac16b2a1a1a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4110,4 +4110,4 @@ snowflake = ["snowflake-sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "8d7028f599c6dd12460911318e2c69e831db0c9d8061b87e6af1449bc2bb1b59"
+content-hash = "d09d5e9e0696f84aabc3b29c15abd625638c1e6058ac0fbaaa5c20058b6e6f46"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240708.1"
+version = "20240708.2.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"
@@ -33,7 +33,7 @@ packaging = ">=21.3,<25.0"
 tenacity = "^8.2.3"
 # optional dependencies
 snowflake-sqlalchemy = { version = "*", optional = true }
-sqlalchemy = { version = "*", optional = true }
+sqlalchemy = { version = "<2.0", optional = true }  # TODO: remove pin once we have tested with sqlalchemy 2.0 & snowflake
 psycopg2-binary = { version = "*", optional = true }
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ orjson = "^3.9.7, !=3.9.10" # TODO: remove inequality once dep resolution issue 
 packaging = ">=21.3,<25.0"
 tenacity = "^8.2.3"
 # optional dependencies
-snowflake-sqlalchemy = { version = "*", optional = true }
-sqlalchemy = { version = "<2.0", optional = true }  # TODO: remove pin once we have tested with sqlalchemy 2.0 & snowflake
+snowflake-sqlalchemy = { version = "<1.6", optional = true } # TODO: remove pin once we have tested with sqlalchemy 2.0 & snowflake
+sqlalchemy = { version = "<2.0", optional = true }  # TODO: see above ^
 psycopg2-binary = { version = "*", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
In preparation for the `snowflake-sqlalchemy` `1.6.0` release that will un-pin `sqlalchemy` 1. 

We need to ensure we don't accidentally move the agent to Snowflake SQLAlchemy 2 without testing it first. 

https://github.com/snowflakedb/snowflake-sqlalchemy/releases/tag/v1.6.0