### PR TITLE
Add org id to event models

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Final
 import orjson
 from great_expectations import get_context  # type: ignore[attr-defined] # TODO: fix this
 from great_expectations.compatibility import pydantic
-from great_expectations.compatibility.pydantic import AmqpDsn, AnyUrl
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from packaging.version import Version
@@ -40,7 +39,7 @@ from great_expectations_cloud.agent.message_service.subscriber import (
     SubscriberError,
 )
 from great_expectations_cloud.agent.models import (
-    AgentBaseModel,
+    AgentBaseExtraForbid,
     JobCompleted,
     JobStarted,
     JobStatus,
@@ -51,6 +50,7 @@ from great_expectations_cloud.agent.models import (
 
 if TYPE_CHECKING:
     import requests
+    from great_expectations.compatibility.pydantic import AmqpDsn, AnyUrl
     from great_expectations.data_context import CloudDataContext
     from typing_extensions import Self
 
@@ -62,7 +62,7 @@ LOGGER.setLevel(logging.INFO)
 HandlerMap = Dict[str, OnMessageCallback]
 
 
-class GXAgentConfig(AgentBaseModel):
+class GXAgentConfig(AgentBaseExtraForbid):
     """GXAgent configuration.
     Attributes:
         queue: name of queue
@@ -91,7 +91,7 @@ def orjson_loads(v: bytes | bytearray | memoryview | str) -> Any:
     return orjson.loads(v)
 
 
-class Payload(AgentBaseModel):
+class Payload(AgentBaseExtraForbid):
     data: Dict[str, Any]  # noqa: UP006  # Python 3.8 requires Dict instead of dict
 
     class Config:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -14,6 +14,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Final
 import orjson
 from great_expectations import get_context  # type: ignore[attr-defined] # TODO: fix this
 from great_expectations.compatibility import pydantic
+from great_expectations.compatibility.pydantic import (  # noqa: TCH002  # cannot be imported in type checking block
+    AmqpDsn,
+    AnyUrl,
+)
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from packaging.version import Version
@@ -50,7 +54,6 @@ from great_expectations_cloud.agent.models import (
 
 if TYPE_CHECKING:
     import requests
-    from great_expectations.compatibility.pydantic import AmqpDsn, AnyUrl
     from great_expectations.data_context import CloudDataContext
     from typing_extensions import Self
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -388,6 +388,7 @@ class GXAgent:
         session = create_session(access_token=self._config.gx_cloud_access_token)
         data = status.json()
         session.patch(agent_sessions_url, data=data)
+        LOGGER.info("Status updated", extra={"job_id": job_id, "status": str(status)})
 
     def _create_scheduled_job_and_set_started(self, event_context: EventContext) -> None:
         """Create a job in GX Cloud for scheduled events.

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -14,10 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Final
 import orjson
 from great_expectations import get_context  # type: ignore[attr-defined] # TODO: fix this
 from great_expectations.compatibility import pydantic
-from great_expectations.compatibility.pydantic import (  # noqa: TCH002  # cannot be imported in type checking block
-    AmqpDsn,
-    AnyUrl,
-)
+from great_expectations.compatibility.pydantic import AmqpDsn, AnyUrl
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from packaging.version import Version

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -87,7 +87,7 @@ class DraftDatasourceConfigEvent(EventBase):
     config_id: UUID
 
 
-class UnknownEvent(EventBase):
+class UnknownEvent(AgentBaseModel):
     type: Literal["unknown_event"] = "unknown_event"
 
 

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -19,6 +19,7 @@ class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any
 
 class EventBase(AgentBaseModel):
     type: str
+    organization_id: UUID
 
     class Config:
         extra: str = Extra.ignore

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -11,18 +11,21 @@ from typing_extensions import Annotated
 from great_expectations_cloud.agent.exceptions import GXCoreError
 
 
-class AgentBaseModel(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
+class AgentBaseExtraForbid(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
     class Config:
         # 2024-03-04: ZEL-501 Strictly enforce models for handling outdated APIs
         extra: str = Extra.forbid
 
 
-class EventBase(AgentBaseModel):
+class AgentBaseExtraIgnore(BaseModel):  # type: ignore[misc] # BaseSettings is has Any type
+    class Config:
+        # Extra fields on Events are not strictly enforced
+        extra: str = Extra.ignore
+
+
+class EventBase(AgentBaseExtraIgnore):
     type: str
     organization_id: UUID
-
-    class Config:
-        extra: str = Extra.ignore
 
 
 class ScheduledEventBase(EventBase):
@@ -87,7 +90,7 @@ class DraftDatasourceConfigEvent(EventBase):
     config_id: UUID
 
 
-class UnknownEvent(AgentBaseModel):
+class UnknownEvent(AgentBaseExtraForbid):
     type: Literal["unknown_event"] = "unknown_event"
 
 
@@ -107,16 +110,16 @@ Event = Annotated[
 ]
 
 
-class CreatedResource(AgentBaseModel):
+class CreatedResource(AgentBaseExtraForbid):
     resource_id: str
     type: str
 
 
-class JobStarted(AgentBaseModel):
+class JobStarted(AgentBaseExtraForbid):
     status: Literal["started"] = "started"
 
 
-class JobCompleted(AgentBaseModel):
+class JobCompleted(AgentBaseExtraForbid):
     status: Literal["completed"] = "completed"
     success: bool
     created_resources: Sequence[CreatedResource] = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -4110,4 +4110,4 @@ snowflake = ["snowflake-sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "8a294e2a9a0012f9435fd160585935cd265a39687b0c8620b0fd7f787ab3d2d2"
+content-hash = "f4cc69c3d48d1842c3e3570d9e610359de4d365678e54910ece9d3fe58e104d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,8 @@ runtime-evaluated-base-classes = [
     # NOTE: ruff is unable to detect that these are subclasses of pydantic.BaseModel
     "pydantic.BaseModel",
     "pydantic.v1.BaseModel",
-    "great_expectations_cloud.agent.models.AgentBaseModel",
+    "great_expectations_cloud.agent.models.AgentBaseExtraForbid",
+    "great_expectations_cloud.agent.models.AgentBaseExtraIgnore",
     "great_expectations_cloud.agent.models.EventBase",
     "great_expectations.datasource.fluent.fluent_base_model.FluentBaseModel",
     "great_expectations.datasource.fluent.interfaces.Datasource",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240708.1"
+version = "20240708.2.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"
@@ -32,8 +32,8 @@ orjson = "^3.9.7, !=3.9.10" # TODO: remove inequality once dep resolution issue 
 packaging = ">=21.3,<25.0"
 tenacity = "^8.2.3"
 # optional dependencies
-snowflake-sqlalchemy = { version = "*", optional = true }
-sqlalchemy = { version = "*", optional = true }
+snowflake-sqlalchemy = { version = "<1.6", optional = true } # TODO: remove pin once we have tested with sqlalchemy 2.0 & snowflake
+sqlalchemy = { version = "<2.0", optional = true }  # TODO: see above ^
 psycopg2-binary = { version = "*", optional = true }
 
 [tool.poetry.extras]

--- a/tests/agent/actions/checkpoints/test_run_checkpoint_action.py
+++ b/tests/agent/actions/checkpoints/test_run_checkpoint_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -28,6 +29,7 @@ run_checkpoint_action_class_and_event = (
         type="run_checkpoint_request",
         datasource_names_to_asset_names={"Data Source 1": {"Data Asset A", "Data Asset B"}},
         checkpoint_id="5f3814d6-a2e2-40f9-ba75-87ddf485c3a8",
+        organization_id=uuid.uuid4(),
     ),
 )
 run_scheduled_checkpoint_action_class_and_event = (
@@ -37,6 +39,7 @@ run_scheduled_checkpoint_action_class_and_event = (
         datasource_names_to_asset_names={"Data Source 1": {"Data Asset A", "Data Asset B"}},
         checkpoint_id="5f3814d6-a2e2-40f9-ba75-87ddf485c3a8",
         schedule_id=UUID("5f3814d6-a2e2-40f9-ba75-87ddf485c3a8"),
+        organization_id=uuid.uuid4(),
     ),
 )
 

--- a/tests/agent/actions/data_assistants/test_run_missingness_data_assistant_action_utils.py
+++ b/tests/agent/actions/data_assistants/test_run_missingness_data_assistant_action_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -26,6 +27,7 @@ def missingness_event_without_expectation_suite_name():
         type="missingness_data_assistant_request.received",
         datasource_name="test-datasource",
         data_asset_name="test-data-asset",
+        organization_id=uuid.uuid4(),
     )
 
 
@@ -36,6 +38,7 @@ def missingness_event_with_expectation_suite_name():
         datasource_name="test-datasource",
         data_asset_name="test-data-asset",
         expectation_suite_name="test-expectation-suite",
+        organization_id=uuid.uuid4(),
     )
 
 

--- a/tests/agent/actions/data_assistants/test_run_onboarding_data_assistant_action.py
+++ b/tests/agent/actions/data_assistants/test_run_onboarding_data_assistant_action.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -27,6 +28,7 @@ def onboarding_event():
         type="onboarding_data_assistant_request.received",
         datasource_name="test-datasource",
         data_asset_name="test-data-asset",
+        organization_id=uuid.uuid4(),
     )
 
 

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -65,7 +65,7 @@ def test_test_draft_datasource_config_success_non_sql_ds(
     _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
 
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -128,7 +128,7 @@ def test_test_draft_datasource_config_success_sql_ds(
     _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
 
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -192,7 +192,7 @@ def test_test_draft_datasource_config_sql_ds_raises_on_patch_failure(
     action = DraftDatasourceConfigAction(context=mock_context)
 
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -224,7 +224,7 @@ def test_test_draft_datasource_config_failure(
     env_vars = GxAgentEnvVars()
     action = DraftDatasourceConfigAction(context=mock_context)
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -250,7 +250,7 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
     env_vars = GxAgentEnvVars()
     action = DraftDatasourceConfigAction(context=mock_context)
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -285,7 +285,7 @@ def test_draft_datasource_config_failure_raises_correct_gx_core_error(
     )
     mock_check_draft_datasource_config.side_effect = TestConnectionError(error_message)
 
-    event = DraftDatasourceConfigEvent(config_id=uuid.uuid4())
+    event = DraftDatasourceConfigEvent(config_id=uuid.uuid4(), organization_id=uuid.uuid4())
     with pytest.raises(GXCoreError) as e:
         action.run(event=event, id=str(uuid.uuid4()))
 
@@ -303,7 +303,7 @@ def test_test_draft_datasource_config_raises_for_unknown_type(
     env_vars = GxAgentEnvVars()
     action = DraftDatasourceConfigAction(context=mock_context)
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"
@@ -330,7 +330,7 @@ def test_test_draft_datasource_config_raises_for_cloud_backend_error(
     env_vars = GxAgentEnvVars()
     action = DraftDatasourceConfigAction(context=mock_context)
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
-    event = DraftDatasourceConfigEvent(config_id=config_id)
+    event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
         f"/datasources/drafts/{config_id}"

--- a/tests/agent/actions/test_list_table_names_action.py
+++ b/tests/agent/actions/test_list_table_names_action.py
@@ -58,6 +58,7 @@ def event():
     return ListTableNamesEvent(
         type="list_table_names_request.received",
         datasource_name="test-datasource",
+        organization_id=uuid.uuid4(),
     )
 
 

--- a/tests/agent/actions/test_run_metrics_list_action.py
+++ b/tests/agent/actions/test_run_metrics_list_action.py
@@ -49,6 +49,7 @@ def test_run_metrics_list_computes_metric_run(
             datasource_name="test-datasource",
             data_asset_name="test-data-asset",
             metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+            organization_id=uuid.uuid4(),
         ),
         id="test-id",
     )
@@ -81,6 +82,7 @@ def test_run_metrics_list_computes_metric_run_missing_batch_inspector(
             datasource_name="test-datasource",
             data_asset_name="test-data-asset",
             metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+            organization_id=uuid.uuid4(),
         ),
         id="test-id",
     )
@@ -111,6 +113,7 @@ def test_run_metrics_list_creates_metric_run(mock_context, mocker: MockerFixture
             datasource_name="test-datasource",
             data_asset_name="test-data-asset",
             metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+            organization_id=uuid.uuid4(),
         ),
         id="test-id",
     )
@@ -139,6 +142,7 @@ def test_run_metrics_list_returns_action_result(mock_context, mocker: MockerFixt
             datasource_name="test-datasource",
             data_asset_name="test-data-asset",
             metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+            organization_id=uuid.uuid4(),
         ),
         id="test-id",
     )
@@ -175,6 +179,7 @@ def test_run_column_descriptive_metrics_raises_on_test_connection_to_data_asset_
                 datasource_name="test-datasource",
                 data_asset_name="test-data-asset",
                 metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+                organization_id=uuid.uuid4(),
             ),
             id="test-id",
         )
@@ -227,6 +232,7 @@ def test_run_metrics_list_creates_metric_run_then_raises_on_any_metric_exception
                 datasource_name="test-datasource",
                 data_asset_name="test-data-asset",
                 metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+                organization_id=uuid.uuid4(),
             ),
             id="test-id",
         )

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -496,6 +496,7 @@ def test_correlation_id_header(
     ds_config_factory: Callable[[str], dict[Literal["name", "type", "connection_string"], str]],
     gx_agent_config: GXAgentConfig,
     fake_subscriber: FakeSubscriber,
+    random_uuid: Callable[[], str],
 ):
     """Ensure agent-job-id/correlation-id header is set on GX Cloud api calls and updated for every new job."""
     agent_job_ids: list[str] = [str(uuid.uuid4()) for _ in range(3)]
@@ -507,13 +508,13 @@ def test_correlation_id_header(
         [
             (
                 DraftDatasourceConfigEvent(
-                    config_id=datasource_config_id_1, organization_id=uuid.uuid4()
+                    config_id=datasource_config_id_1, organization_id=random_uuid
                 ),
                 agent_job_ids[0],
             ),
             (
                 DraftDatasourceConfigEvent(
-                    config_id=datasource_config_id_2, organization_id=uuid.uuid4()
+                    config_id=datasource_config_id_2, organization_id=random_uuid
                 ),
                 agent_job_ids[1],
             ),
@@ -521,7 +522,7 @@ def test_correlation_id_header(
                 RunCheckpointEvent(
                     checkpoint_id=checkpoint_id,
                     datasource_names_to_asset_names={},
-                    organization_id=uuid.uuid4(),
+                    organization_id=random_uuid,
                 ),
                 agent_job_ids[2],
             ),

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -279,7 +279,9 @@ def test_gx_agent_updates_cloud_on_job_status(
     async def redeliver_message():
         return None
 
-    event = RunOnboardingDataAssistantEvent(datasource_name="test-ds", data_asset_name="test-da")
+    event = RunOnboardingDataAssistantEvent(
+        datasource_name="test-ds", data_asset_name="test-da", organization_id=uuid.uuid4()
+    )
 
     end_test = False
 
@@ -349,6 +351,7 @@ def test_gx_agent_sends_request_to_create_scheduled_job(
         datasource_names_to_asset_names={},
         splitter_options=None,
         schedule_id=schedule_id,
+        organization_id=uuid.uuid4(),
     )
     payload = Payload(
         data={
@@ -502,10 +505,24 @@ def test_correlation_id_header(
     # seed the fake queue with an event that will be consumed by the agent
     fake_subscriber.test_queue.extendleft(
         [
-            (DraftDatasourceConfigEvent(config_id=datasource_config_id_1), agent_job_ids[0]),
-            (DraftDatasourceConfigEvent(config_id=datasource_config_id_2), agent_job_ids[1]),
             (
-                RunCheckpointEvent(checkpoint_id=checkpoint_id, datasource_names_to_asset_names={}),
+                DraftDatasourceConfigEvent(
+                    config_id=datasource_config_id_1, organization_id=uuid.uuid4()
+                ),
+                agent_job_ids[0],
+            ),
+            (
+                DraftDatasourceConfigEvent(
+                    config_id=datasource_config_id_2, organization_id=uuid.uuid4()
+                ),
+                agent_job_ids[1],
+            ),
+            (
+                RunCheckpointEvent(
+                    checkpoint_id=checkpoint_id,
+                    datasource_names_to_asset_names={},
+                    organization_id=uuid.uuid4(),
+                ),
                 agent_job_ids[2],
             ),
         ]

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
+import orjson
 import packaging.version
 import pytest
 from great_expectations.experimental.metric_repository.metrics import (
     MetricTypes,
 )
-from orjson import orjson
 from typing_extensions import override
 
 from great_expectations_cloud.agent.actions import (

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
@@ -9,6 +8,7 @@ import pytest
 from great_expectations.experimental.metric_repository.metrics import (
     MetricTypes,
 )
+from orjson import orjson
 from typing_extensions import override
 
 from great_expectations_cloud.agent.actions import (
@@ -54,6 +54,7 @@ def example_event():
         type="onboarding_data_assistant_request.received",
         datasource_name="abc",
         data_asset_name="boo",
+        organization_id=uuid4(),
     )
 
 
@@ -74,13 +75,16 @@ class TestEventHandler:
                 RunMissingnessDataAssistantEvent(
                     datasource_name="test-datasource",
                     data_asset_name="test-data-asset",
+                    organization_id=uuid4(),
                 ),
                 RunMissingnessDataAssistantAction,
             ),
             (
                 "RunOnboardingDataAssistantEvent",
                 RunOnboardingDataAssistantEvent(
-                    datasource_name="test-datasource", data_asset_name="test-data-asset"
+                    datasource_name="test-datasource",
+                    data_asset_name="test-data-asset",
+                    organization_id=uuid4(),
                 ),
                 RunOnboardingDataAssistantAction,
             ),
@@ -89,17 +93,21 @@ class TestEventHandler:
                 RunCheckpointEvent(
                     checkpoint_id="3ecd140b-1dd5-41f4-bdb1-c8009d4f1940",
                     datasource_names_to_asset_names={"Data Source name": {"Asset name"}},
+                    organization_id=uuid4(),
                 ),
                 RunCheckpointAction,
             ),
             (
                 "DraftDatasourceConfigEvent",
-                DraftDatasourceConfigEvent(config_id=uuid4()),
+                DraftDatasourceConfigEvent(
+                    config_id=uuid4(),
+                    organization_id=uuid4(),
+                ),
                 DraftDatasourceConfigAction,
             ),
             (
                 "ListTableNamesEvent",
-                ListTableNamesEvent(datasource_name="test-datasource"),
+                ListTableNamesEvent(datasource_name="test-datasource", organization_id=uuid4()),
                 ListTableNamesAction,
             ),
             (
@@ -108,6 +116,7 @@ class TestEventHandler:
                     datasource_name="test-datasource",
                     data_asset_name="test-data-asset",
                     metric_names=[MetricTypes.TABLE_COLUMN_TYPES, MetricTypes.TABLE_COLUMNS],
+                    organization_id=uuid4(),
                 ),
                 MetricListAction,
             ),
@@ -204,7 +213,7 @@ class TestEventHandlerRegistry:
 def test_parse_event_extra_field_is_ignored(example_event):
     event_dict = example_event.dict()
     event_dict["new_field"] = "surprise!"
-    serialized_bytes = json.dumps(dict(event_dict), indent=2).encode("utf-8")
+    serialized_bytes = orjson.dumps(event_dict)
     event = EventHandler.parse_event_from(serialized_bytes)
 
     # Extra field is ignored, which allows request to still be received - ZELDA-770
@@ -213,7 +222,7 @@ def test_parse_event_extra_field_is_ignored(example_event):
 
 def test_parse_event_missing_required_field(example_event):
     event_dict = example_event.dict(exclude={"datasource_name"})
-    serialized_bytes = json.dumps(dict(event_dict)).encode("utf-8")
+    serialized_bytes = orjson.dumps(event_dict)
     event = EventHandler.parse_event_from(serialized_bytes)
 
     assert event.type == "unknown_event"
@@ -222,7 +231,7 @@ def test_parse_event_missing_required_field(example_event):
 def test_parse_event_invalid_json(example_event):
     event_dict = example_event.dict()
     invalid_json_addition = "}}}}"
-    serialized_bytes = (json.dumps(dict(event_dict)) + invalid_json_addition).encode("utf-8")
+    serialized_bytes = (orjson.dumps(event_dict).decode() + invalid_json_addition).encode("utf-8")
     event = EventHandler.parse_event_from(serialized_bytes)
 
     assert event.type == "unknown_event"

--- a/tests/integration/actions/test_checkpoint_action.py
+++ b/tests/integration/actions/test_checkpoint_action.py
@@ -199,11 +199,12 @@ def checkpoint(
 
 
 @pytest.fixture
-def checkpoint_event(checkpoint, datasource_names_to_asset_names):
+def checkpoint_event(checkpoint, datasource_names_to_asset_names, org_id_env_var: str):
     return RunCheckpointEvent(
         type="run_checkpoint_request",
         checkpoint_id=checkpoint.ge_cloud_id,
         datasource_names_to_asset_names=datasource_names_to_asset_names,
+        organization_id=uuid.UUID(org_id_env_var),
     )
 
 

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.integration
 
 
-def test_running_draft_datasource_config_action(context: CloudDataContext, mocker: MockerFixture):
+def test_running_draft_datasource_config_action(
+    context: CloudDataContext, org_id_env_var: str, mocker: MockerFixture
+):
     # Arrange
     # Note: Draft config is loaded in mercury seed data
 
@@ -28,6 +30,7 @@ def test_running_draft_datasource_config_action(context: CloudDataContext, mocke
     draft_datasource_config_event = DraftDatasourceConfigEvent(
         type="test_datasource_config",
         config_id=draft_datasource_id_for_connect_successfully,
+        organization_id=UUID(org_id_env_var),
     )
     event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
@@ -86,7 +89,7 @@ def test_running_draft_datasource_config_action(context: CloudDataContext, mocke
 
 
 def test_running_draft_datasource_config_action_fails_for_unreachable_datasource(
-    context: CloudDataContext,
+    context: CloudDataContext, org_id_env_var: str
 ):
     # Arrange
     # Note: Draft config is loaded in mercury seed data
@@ -98,6 +101,7 @@ def test_running_draft_datasource_config_action_fails_for_unreachable_datasource
     draft_datasource_config_event = DraftDatasourceConfigEvent(
         type="test_datasource_config",
         config_id=datasource_id_for_connect_failure,
+        organization_id=UUID(org_id_env_var),
     )
     event_id = "64842838-c7bf-4038-8b27-c7a32eba4b7b"
 

--- a/tests/integration/actions/test_metric_list_action.py
+++ b/tests/integration/actions/test_metric_list_action.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -114,6 +115,7 @@ def test_running_metric_list_action(
     query: str,
     local_mercury_db_datasource: PostgresDatasource,
     local_mercury_db_organizations_table_asset: TableAsset,
+    org_id_env_var: str,
 ):
     # MetricListEvent with only the Table Metrics requested
     metrics_list_event = RunMetricsListEvent(
@@ -125,6 +127,7 @@ def test_running_metric_list_action(
             MetricTypes.TABLE_COLUMNS,
             MetricTypes.TABLE_ROW_COUNT,
         ],
+        organization_id=uuid.UUID(org_id_env_var),
     )
 
     action = MetricListAction(context=context)


### PR DESCRIPTION
Pass the org id to the GX Runner via the event by adding to all of the event models. The org id is needed by the runner to pull the correct context configuration related to the org before running the selected action. [Demo Video](https://us02web.zoom.us/clips/share/eA0CfUsBJhTt2KsQ1T3S70Mu4x2ixSpNVkmZmCjgqLGASFskk6ENTuXo32olPeFlOfY8QeYnluXy84ObQ8qu42EY.SA8Y2kDXARYFW95c)

See also https://github.com/greatexpectationslabs/mercury/pull/3514 for the related backend change which should merge first.