### PR TITLE
mypy - enable `possibly-undefined`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,11 @@ follow_imports = 'normal'
 warn_redundant_casts = true
 show_error_codes = true
 implicit_reexport = true                                         # enabled due to strict mode
-enable_error_code = ['ignore-without-code', 'explicit-override']
+enable_error_code = [
+    'ignore-without-code',
+    'explicit-override',
+    'possibly-undefined',
+]
 
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240708.2.dev0"
+version = "20240709.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Enable the `possible-undefined` optional mypy rule.

>## Warn about variables that are defined only in some execution paths
>
>mypy generates an error if it cannot verify that a variable will be defined in all execution >paths. This includes situations when a variable definition appears in a loop, in a >conditional branch, in an except handler, etc. For example:

```python
from typing import Iterable

def test(values: Iterable[int], flag: bool) -> None:
    if flag:
        a = 1
    z = a + 1  # Error: Name "a" may be undefined [possibly-undefined]

    for v in values:
        b = v
    z = b + 1  # Error: Name "b" may be undefined [possibly-undefined]
```

https://mypy.readthedocs.io/en/stable/error_code_list2.html#warn-about-variables-that-are-defined-only-in-some-execution-paths-possibly-undefined

### See also
- [playground](https://mypy-play.net/?mypy=latest&python=3.12&gist=ce99a37c2c2d71e7af2f2852c4b67941) that @tyler-hoffman totally didn't steal from [stackoverflow](https://stackoverflow.com/questions/78191580/how-to-catch-potentially-undefined-variables-with-pylint-or-mypy)
- https://github.com/greatexpectationslabs/mercury/pull/3440
- https://github.com/great-expectations/great_expectations/pull/10091
- https://github.com/great-expectations/great_expectations/pull/10092