### PR TITLE
Make org ID optional on events

### DIFF
--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -25,7 +25,7 @@ class AgentBaseExtraIgnore(BaseModel):
 
 class EventBase(AgentBaseExtraIgnore):
     type: str
-    organization_id: UUID | None = None
+    organization_id: Optional[UUID] = None
 
 
 class ScheduledEventBase(EventBase):

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -25,7 +25,7 @@ class AgentBaseExtraIgnore(BaseModel):
 
 class EventBase(AgentBaseExtraIgnore):
     type: str
-    organization_id: UUID
+    organization_id: UUID | None = None
 
 
 class ScheduledEventBase(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240710.0.dev0"
+version = "20240710.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Make org ID optional until we can backfill org_id on existing schedules. See also: https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1720642064478209 and https://github.com/greatexpectationslabs/mercury/pull/3524