### PR TITLE
Refactor HandleEvent workflow to take in DataContext as parameter

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -216,7 +216,7 @@ class GXAgent:
         self._current_task = self._executor.submit(
             self._handle_event,
             event_context=event_context,
-            data_context=self._get_data_context(event_context=event_context),
+            data_context=self.get_data_context(event_context=event_context),
         )
 
         if self._current_task is not None:
@@ -226,7 +226,7 @@ class GXAgent:
             )
             self._current_task.add_done_callback(on_exit_callback)
 
-    def _get_data_context(self, event_context: EventContext) -> CloudDataContext:
+    def get_data_context(self, event_context: EventContext) -> CloudDataContext:
         """Helper method to get a DataContext Agent. Overriden in GX-Runner."""
         return self._context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240710.0"
+version = "20240712.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Updating Handle-Event workflow in Agent.
* No behavior is changed, just a helper method is added, and `_handle_event` takes in one additional parameter (`data_context`),  which is then passed to the `EventHandler` rather than `self._data_context` directly. 
* Why is this needed? 
  * GX-Runner inherits from GX-Agent, and requires a DataContext to be retrieved per-event. 
  * This means are able to override the `_get_data_context()` method in the runner repo and keep the event handling behavior consistent between GX-Agent and GX-runner. 
   * [PR in GX-runner that enables it to retrieve a DataContext per event](https://github.com/greatexpectationslabs/gx-runner/pull/58)