### PR TITLE
Add `service_name` to agent env variables and logs

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -75,7 +75,6 @@ class GXAgentConfig(AgentBaseExtraForbid):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL  # type: ignore[assignment] # pydantic will coerce
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
-    service_name: str
 
 
 def orjson_dumps(v: Any, *, default: Callable[[Any], Any] | None) -> str:
@@ -344,7 +343,6 @@ class GXAgent:
             self._correlation_ids.clear()
         return should_reject
 
-    # todo: remove this method in favor of get_config
     @classmethod
     def _get_config(cls) -> GXAgentConfig:
         """Construct GXAgentConfig."""

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -390,50 +390,6 @@ class GXAgent:
                 generate_config_validation_error_text(validation_err)
             ) from validation_err
 
-    def get_config() -> GXAgentConfig:
-        """Construct GXAgentConfig."""
-
-        # ensure we have all required env variables, and provide a useful error if not
-
-        try:
-            env_vars = GxAgentEnvVars()
-        except pydantic_v1.ValidationError as validation_err:
-            raise GXAgentConfigError(
-                generate_config_validation_error_text(validation_err)
-            ) from validation_err
-
-        # obtain the broker url and queue name from Cloud
-        agent_sessions_url = (
-            f"{env_vars.gx_cloud_base_url}/organizations/"
-            f"{env_vars.gx_cloud_organization_id}/agent-sessions"
-        )
-
-        session = create_session(access_token=env_vars.gx_cloud_access_token)
-
-        response = session.post(agent_sessions_url)
-        if response.ok is not True:
-            raise GXAgentError(  # noqa: TRY003 # TODO: use AuthenticationError
-                "Unable to authenticate to GX Cloud. Please check your credentials."
-            )
-
-        json_response = response.json()
-        queue = json_response["queue"]
-        connection_string = json_response["connection_string"]
-
-        try:
-            # pydantic will coerce the url to the correct type
-            return GXAgentConfig(
-                queue=queue,
-                connection_string=connection_string,
-                gx_cloud_base_url=env_vars.gx_cloud_base_url,
-                gx_cloud_organization_id=env_vars.gx_cloud_organization_id,
-                gx_cloud_access_token=env_vars.gx_cloud_access_token,
-            )
-        except pydantic_v1.ValidationError as validation_err:
-            raise GXAgentConfigError(
-                generate_config_validation_error_text(validation_err)
-            ) from validation_err
-
     def _update_status(self, job_id: str, status: JobStatus) -> None:
         """Update GX Cloud on the status of a job.
 

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from pydantic.v1 import AnyUrl, BaseSettings, ValidationError
 
+from great_expectations_cloud.agent.constants import SERVICE_NAME
+
 
 class GxAgentEnvVars(BaseSettings):
     # pydantic will coerce this string to AnyUrl type
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL  # type: ignore[assignment]
-    gx_cloud_organization_id: str = ""
-    gx_cloud_access_token: str = ""
-    service_name: str = "gx-agent"
+    service_name: str = SERVICE_NAME
+    gx_cloud_organization_id: str
+    gx_cloud_access_token: str
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -7,8 +7,8 @@ from pydantic.v1 import AnyUrl, BaseSettings, ValidationError
 class GxAgentEnvVars(BaseSettings):
     # pydantic will coerce this string to AnyUrl type
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL  # type: ignore[assignment]
-    gx_cloud_organization_id: str
-    gx_cloud_access_token: str
+    gx_cloud_organization_id: str = ""
+    gx_cloud_access_token: str = ""
     service_name: str = "gx-agent"
 
     def __init__(self, **overrides: str | AnyUrl) -> None:

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -9,6 +9,7 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL  # type: ignore[assignment]
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
+    service_name: str = "gx-agent"
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/great_expectations_cloud/agent/constants.py
+++ b/great_expectations_cloud/agent/constants.py
@@ -9,6 +9,7 @@ class HeaderName(str, enum.Enum):
     AGENT_JOB_ID = "Agent-Job-Id"
 
 
-USER_AGENT_HEADER: Final = "gx-agent"
+USER_AGENT_HEADER: Final[str] = "gx-agent"
+SERVICE_NAME: Final[str] = "gx-agent"
 
 __all__ = ["USER_AGENT_HEADER"]

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -12,13 +12,13 @@ from typing import Any, ClassVar, Final, Literal
 
 from typing_extensions import override
 
-from great_expectations_cloud.agent import GXAgent
+from great_expectations_cloud.agent.config import GxAgentEnvVars
 
 LOGGER = logging.getLogger(__name__)
-
+env_vars = GxAgentEnvVars()
 DEFAULT_LOG_FILE: Final[str] = "logfile"
 DEFAULT_LOG_DIR = "logs"
-SERVICE_NAME: Final[str] = GXAgent.get_config().service_name
+SERVICE_NAME: Final[str] = env_vars.service_name
 DEFAULT_FILE_LOGGING_LEVEL: Final[int] = logging.DEBUG
 
 # Consider moving to file

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -15,10 +15,9 @@ from typing_extensions import override
 from great_expectations_cloud.agent.config import GxAgentEnvVars
 
 LOGGER = logging.getLogger(__name__)
-env_vars = GxAgentEnvVars()
 DEFAULT_LOG_FILE: Final[str] = "logfile"
 DEFAULT_LOG_DIR = "logs"
-SERVICE_NAME: Final[str] = env_vars.service_name
+SERVICE_NAME: Final[str] = GxAgentEnvVars().service_name
 DEFAULT_FILE_LOGGING_LEVEL: Final[int] = logging.DEBUG
 
 # Consider moving to file

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -18,7 +18,9 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_LOG_FILE: Final[str] = "logfile"
 DEFAULT_LOG_DIR = "logs"
-SERVICE_NAME: Final[str] = GxAgentEnvVars().service_name
+env_vars = GxAgentEnvVars()
+SERVICE_NAME = env_vars.service_name
+
 DEFAULT_FILE_LOGGING_LEVEL: Final[int] = logging.DEBUG
 
 # Consider moving to file

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -12,11 +12,13 @@ from typing import Any, ClassVar, Final, Literal
 
 from typing_extensions import override
 
+from great_expectations_cloud.agent import GXAgent
+
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_LOG_FILE: Final[str] = "logfile"
 DEFAULT_LOG_DIR = "logs"
-SERVICE_NAME: Final[str] = "gx-agent"
+SERVICE_NAME: Final[str] = GXAgent.get_config().service_name
 DEFAULT_FILE_LOGGING_LEVEL: Final[int] = logging.DEBUG
 
 # Consider moving to file

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -15,6 +15,7 @@ from typing_extensions import override
 from great_expectations_cloud.agent.config import GxAgentEnvVars
 
 LOGGER = logging.getLogger(__name__)
+
 DEFAULT_LOG_FILE: Final[str] = "logfile"
 DEFAULT_LOG_DIR = "logs"
 SERVICE_NAME: Final[str] = GxAgentEnvVars().service_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240715.0.dev1"
+version = "20240716.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240715.0.dev0"
+version = "20240715.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/test_logging_cfg.py
+++ b/tests/test_logging_cfg.py
@@ -10,6 +10,7 @@ from typing import Any
 import freezegun
 import pytest
 
+# todo: fix this. this import is erroring because the env variables for org ID and token aren't set at this point
 from great_expectations_cloud.logging.logging_cfg import (
     DEFAULT_LOG_DIR,
     DEFAULT_LOG_FILE,


### PR DESCRIPTION
* Adds service name to the Agent env variables for use in logs
* This is to allow the GXRunner to override the service name to be `gx-runner` 