### PR TITLE
Use overridable methods for org ID and auth token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240716.1.dev0"
+version = "20240717.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
The runner needs to retrieve these values differently. Adding two small methods we can override in the runner to keep the code consistent. We can diverge later if needed.