### PR TITLE
Pass in base_url, org ID and auth key to each action

### DIFF
--- a/great_expectations_cloud/agent/actions/agent_action.py
+++ b/great_expectations_cloud/agent/actions/agent_action.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Generic, Optional, Sequence, TypeVar
+from uuid import UUID
 
 from pydantic.v1 import BaseModel
 
@@ -23,8 +24,13 @@ _EventT = TypeVar("_EventT", bound=Event)
 
 
 class AgentAction(Generic[_EventT]):
-    def __init__(self, context: CloudDataContext):
+    def __init__(
+        self, context: CloudDataContext, base_url: str, organization_id: UUID, auth_key: str
+    ):
         self._context = context
+        self._base_url = base_url
+        self._organization_id = organization_id
+        self._auth_key = auth_key
 
     @abstractmethod
     def run(self, event: _EventT, id: str) -> ActionResult: ...

--- a/great_expectations_cloud/agent/actions/data_assistants/run_missingness_data_assistant.py
+++ b/great_expectations_cloud/agent/actions/data_assistants/run_missingness_data_assistant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from typing_extensions import override
 
@@ -18,8 +19,12 @@ if TYPE_CHECKING:
 
 
 class RunMissingnessDataAssistantAction(AgentAction[RunMissingnessDataAssistantEvent]):
-    def __init__(self, context: CloudDataContext):
-        super().__init__(context=context)
+    def __init__(
+        self, context: CloudDataContext, base_url: str, organization_id: UUID, auth_key: str
+    ):
+        super().__init__(
+            context=context, base_url=base_url, organization_id=organization_id, auth_key=auth_key
+        )
         self._data_assistant = self._context.assistants.missingness
 
     @override

--- a/great_expectations_cloud/agent/actions/data_assistants/run_onboarding_data_assistant.py
+++ b/great_expectations_cloud/agent/actions/data_assistants/run_onboarding_data_assistant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from typing_extensions import override
 
@@ -18,8 +19,12 @@ if TYPE_CHECKING:
 
 
 class RunOnboardingDataAssistantAction(AgentAction[RunOnboardingDataAssistantEvent]):
-    def __init__(self, context: CloudDataContext):
-        super().__init__(context=context)
+    def __init__(
+        self, context: CloudDataContext, base_url: str, organization_id: UUID, auth_key: str
+    ):
+        super().__init__(
+            context=context, base_url=base_url, organization_id=organization_id, auth_key=auth_key
+        )
         self._data_assistant = self._context.assistants.onboarding
 
     @override

--- a/great_expectations_cloud/agent/actions/run_metric_list_action.py
+++ b/great_expectations_cloud/agent/actions/run_metric_list_action.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from great_expectations.experimental.metric_repository.batch_inspector import (
     BatchInspector,
@@ -32,13 +33,18 @@ class MetricListAction(AgentAction[RunMetricsListEvent]):
     # TODO: New actions need to be created that are compatible with GX v1 and registered for v1.
     #  This action is registered for v0, see register_event_action()
 
-    def __init__(
+    def __init__(  # noqa: PLR0913  # Refactor opportunity
         self,
         context: CloudDataContext,
+        base_url: str,
+        organization_id: UUID,
+        auth_key: str,
         metric_repository: MetricRepository | None = None,
         batch_inspector: BatchInspector | None = None,
     ):
-        super().__init__(context=context)
+        super().__init__(
+            context=context, base_url=base_url, organization_id=organization_id, auth_key=auth_key
+        )
         self._metric_repository = metric_repository or MetricRepository(
             data_store=CloudDataStore(self._context)
         )

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -255,6 +255,8 @@ class GXAgent:
         """
         # warning:  this method will not be executed in the main thread
         organization_id = self.get_organization_id(event_context)
+        base_url = self._config.gx_cloud_base_url
+        auth_key = self.get_auth_key()
 
         if isinstance(event_context.event, ScheduledEventBase):
             self._create_scheduled_job_and_set_started(event_context)
@@ -273,7 +275,13 @@ class GXAgent:
         )
         handler = EventHandler(context=data_context)
         # This method might raise an exception. Allow it and handle in _handle_event_as_thread_exit
-        result = handler.handle_event(event=event_context.event, id=event_context.correlation_id)
+        result = handler.handle_event(
+            event=event_context.event,
+            id=event_context.correlation_id,
+            base_url=base_url,
+            auth_key=auth_key,
+            organization_id=organization_id,
+        )
         return result
 
     def _handle_event_as_thread_exit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240717.0.dev1"
+version = "20240717.0.dev2"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/checkpoints/test_run_checkpoint_action.py
+++ b/tests/agent/actions/checkpoints/test_run_checkpoint_action.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.unit
 
+
 run_checkpoint_action_class_and_event = (
     RunCheckpointAction,
     RunCheckpointEvent(
@@ -62,7 +63,9 @@ run_scheduled_checkpoint_action_class_and_event = (
 def test_run_checkpoint_action_with_and_without_splitter_options_returns_action_result(
     mock_context, action_class, event, splitter_options, batch_request
 ):
-    action = action_class(context=mock_context)
+    action = action_class(
+        context=mock_context, base_url="", organization_id=uuid.uuid4(), auth_key=""
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     checkpoint = mock_context.run_checkpoint.return_value
     checkpoint_id_str = "5f3814d6-a2e2-40f9-ba75-87ddf485c3a8"
@@ -104,7 +107,9 @@ def test_run_checkpoint_action_raises_on_test_connection_failure(
     mock_context.get_datasource.return_value = mock_datasource
     mock_datasource.test_connection.side_effect = TestConnectionError()
 
-    action = action_class(context=mock_context)
+    action = action_class(
+        context=mock_context, base_url="", organization_id=uuid.uuid4(), auth_key=""
+    )
 
     with pytest.raises(TestConnectionError):
         action.run(

--- a/tests/agent/actions/data_assistants/test_run_missingness_data_assistant_action_utils.py
+++ b/tests/agent/actions/data_assistants/test_run_missingness_data_assistant_action_utils.py
@@ -45,7 +45,9 @@ def missingness_event_with_expectation_suite_name():
 def test_run_missingness_data_assistant_action_without_expectation_suite_name(
     mock_context, missingness_event_without_expectation_suite_name, mocker: MockerFixture
 ):
-    action = RunMissingnessDataAssistantAction(context=mock_context)
+    action = RunMissingnessDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = StoreBackendError("test-message")
     mock_context.get_checkpoint.side_effect = StoreBackendError("test-message")
@@ -71,7 +73,9 @@ def test_run_missingness_data_assistant_action_without_expectation_suite_name(
 def test_run_missingness_data_assistant_action_with_expectation_suite_name(
     mock_context, missingness_event_with_expectation_suite_name, mocker: MockerFixture
 ):
-    action = RunMissingnessDataAssistantAction(context=mock_context)
+    action = RunMissingnessDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     expectation_suite_id = "084a6e0f-c014-4e40-b6b7-b2f57cb9e176"
     checkpoint_id = "f5d32bbf-1392-4248-bc40-a3966fab2e0e"

--- a/tests/agent/actions/data_assistants/test_run_onboarding_data_assistant_action.py
+++ b/tests/agent/actions/data_assistants/test_run_onboarding_data_assistant_action.py
@@ -35,7 +35,9 @@ def onboarding_event():
 def test_run_onboarding_data_assistant_event_raises_for_legacy_datasource(
     mock_context, onboarding_event, mocker: MockerFixture
 ):
-    action = RunOnboardingDataAssistantAction(context=mock_context)
+    action = RunOnboardingDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = StoreBackendError("test-message")
     mock_context.get_checkpoint.side_effect = StoreBackendError("test-message")
@@ -49,7 +51,9 @@ def test_run_onboarding_data_assistant_event_raises_for_legacy_datasource(
 def test_run_onboarding_data_assistant_event_creates_expectation_suite(
     mock_context, onboarding_event, mocker: MockerFixture
 ):
-    action = RunOnboardingDataAssistantAction(context=mock_context)
+    action = RunOnboardingDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = DataContextError("test-message")
     mock_context.get_checkpoint.side_effect = DataContextError("test-message")
@@ -70,7 +74,9 @@ def test_run_onboarding_data_assistant_event_creates_expectation_suite(
 def test_run_onboarding_data_assistant_event_creates_checkpoint(
     mock_context, onboarding_event, mocker: MockerFixture
 ):
-    action = RunOnboardingDataAssistantAction(context=mock_context)
+    action = RunOnboardingDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = DataContextError("test-message")
     mock_context.get_checkpoint.side_effect = DataContextError("test-message")
@@ -109,7 +115,9 @@ def test_run_onboarding_data_assistant_event_creates_checkpoint(
 def test_run_onboarding_data_assistant_action_returns_action_result(
     mock_context, onboarding_event, mocker: MockerFixture
 ):
-    action = RunOnboardingDataAssistantAction(context=mock_context)
+    action = RunOnboardingDataAssistantAction(
+        context=mock_context, base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = StoreBackendError("test-message")
     mock_context.get_checkpoint.side_effect = StoreBackendError("test-message")

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -62,7 +62,7 @@ def test_test_draft_datasource_config_success_non_sql_ds(
     env_vars = GxAgentEnvVars()
     action = DraftDatasourceConfigAction(
         context=mock_context,
-        base_url=" https://api.greatexpectations.io/",
+        base_url="https://test-base-url",
         auth_key="",
         organization_id=org_id,
     )
@@ -130,7 +130,7 @@ def test_test_draft_datasource_config_success_sql_ds(
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
-        base_url=" https://api.greatexpectations.io/",
+        base_url="https://test-base-url",
         auth_key="",
         organization_id=org_id,
     )
@@ -204,7 +204,7 @@ def test_test_draft_datasource_config_sql_ds_raises_on_patch_failure(
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
-        base_url=" https://api.greatexpectations.io/",
+        base_url="https://test-base-url",
         auth_key="",
         organization_id=org_id,
     )
@@ -240,7 +240,7 @@ def test_test_draft_datasource_config_failure(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    base_url = " https://api.greatexpectations.io/"
+    base_url = "https://test-base-url"
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
@@ -273,7 +273,7 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    base_url = " https://api.greatexpectations.io/"
+    base_url = "https://test-base-url"
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
@@ -311,7 +311,7 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
 def test_draft_datasource_config_failure_raises_correct_gx_core_error(
     mock_context, mocker: MockerFixture, error_message: str, expected_error_code: str
 ):
-    base_url = " https://api.greatexpectations.io/"
+    base_url = "https://test-base-url"
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
@@ -340,7 +340,7 @@ def test_test_draft_datasource_config_raises_for_unknown_type(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    base_url = " https://api.greatexpectations.io/"
+    base_url = "https://test-base-url"
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,
@@ -374,7 +374,7 @@ def test_test_draft_datasource_config_raises_for_cloud_backend_error(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    base_url = " https://api.greatexpectations.io/"
+    base_url = "https://test-base-url"
     org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     action = DraftDatasourceConfigAction(
         context=mock_context,

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -33,6 +33,7 @@ def token():
 @pytest.fixture
 def set_required_env_vars(monkeypatch, org_id, token) -> None:
     env_vars = {
+        "GX_CLOUD_BASE_URL": "https://test-base-url",
         "GX_CLOUD_ORGANIZATION_ID": org_id,
         "GX_CLOUD_ACCESS_TOKEN": token,
     }

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -58,8 +58,14 @@ def test_test_draft_datasource_config_success_non_sql_ds(
 ):
     datasource_config = {"type": "pandas", "name": "test-1-2-3"}
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=" https://api.greatexpectations.io/",
+        auth_key="",
+        organization_id=org_id,
+    )
 
     _get_table_names_spy = mocker.spy(action, "_get_table_names")
     _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
@@ -121,7 +127,13 @@ def test_test_draft_datasource_config_success_sql_ds(
     mock_inspector.get_table_names.return_value = table_names
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=" https://api.greatexpectations.io/",
+        auth_key="",
+        organization_id=org_id,
+    )
 
     # add spies to the action methods
     _get_table_names_spy = mocker.spy(action, "_get_table_names")
@@ -189,7 +201,13 @@ def test_test_draft_datasource_config_sql_ds_raises_on_patch_failure(
     mock_inspector.get_table_names.return_value = table_names
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=" https://api.greatexpectations.io/",
+        auth_key="",
+        organization_id=org_id,
+    )
 
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
@@ -222,7 +240,14 @@ def test_test_draft_datasource_config_failure(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    base_url = " https://api.greatexpectations.io/"
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=base_url,
+        auth_key="",
+        organization_id=org_id,
+    )
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
@@ -248,7 +273,14 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    base_url = " https://api.greatexpectations.io/"
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=base_url,
+        auth_key="",
+        organization_id=org_id,
+    )
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
@@ -279,7 +311,14 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
 def test_draft_datasource_config_failure_raises_correct_gx_core_error(
     mock_context, mocker: MockerFixture, error_message: str, expected_error_code: str
 ):
-    action = DraftDatasourceConfigAction(context=mock_context)
+    base_url = " https://api.greatexpectations.io/"
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=base_url,
+        auth_key="",
+        organization_id=org_id,
+    )
     mock_check_draft_datasource_config = mocker.patch(
         f"{DraftDatasourceConfigAction.__module__}.{DraftDatasourceConfigAction.__name__}.check_draft_datasource_config"
     )
@@ -301,7 +340,14 @@ def test_test_draft_datasource_config_raises_for_unknown_type(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    base_url = " https://api.greatexpectations.io/"
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=base_url,
+        auth_key="",
+        organization_id=org_id,
+    )
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
@@ -328,7 +374,14 @@ def test_test_draft_datasource_config_raises_for_cloud_backend_error(
     config_id = UUID("df02b47c-e1b8-48a8-9aaa-b6ed9c49ffa5")
 
     env_vars = GxAgentEnvVars()
-    action = DraftDatasourceConfigAction(context=mock_context)
+    base_url = " https://api.greatexpectations.io/"
+    org_id = UUID("81f4e105-e37d-4168-85a0-2526943f9956")
+    action = DraftDatasourceConfigAction(
+        context=mock_context,
+        base_url=base_url,
+        auth_key="",
+        organization_id=org_id,
+    )
     job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (

--- a/tests/agent/actions/test_list_table_names_action.py
+++ b/tests/agent/actions/test_list_table_names_action.py
@@ -65,7 +65,12 @@ def event():
 def test_list_table_names_event_raises_for_non_sql_datasource(
     mock_context, event, mocker: MockerFixture
 ):
-    action = ListTableNamesAction(context=mock_context)
+    action = ListTableNamesAction(
+        context=mock_context,
+        base_url="https://api.greatexpectations.io/",
+        organization_id=uuid.uuid4(),
+        auth_key="",
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
     mock_context.get_expectation_suite.side_effect = StoreBackendError("test-message")
     mock_context.get_checkpoint.side_effect = StoreBackendError("test-message")
@@ -80,7 +85,12 @@ def test_list_table_names_event_raises_for_non_sql_datasource(
 def test_run_list_table_names_action_returns_action_result(
     mock_context, event, dummy_base_url, dummy_org_id, set_required_env_vars, mocker: MockerFixture
 ):
-    action = ListTableNamesAction(context=mock_context)
+    action = ListTableNamesAction(
+        context=mock_context,
+        base_url="https://api.greatexpectations.io/",
+        organization_id=uuid.uuid4(),
+        auth_key="",
+    )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
     mock_inspect = mocker.patch("great_expectations_cloud.agent.actions.list_table_names.inspect")

--- a/tests/agent/actions/test_list_table_names_action.py
+++ b/tests/agent/actions/test_list_table_names_action.py
@@ -87,8 +87,8 @@ def test_run_list_table_names_action_returns_action_result(
 ):
     action = ListTableNamesAction(
         context=mock_context,
-        base_url="https://api.greatexpectations.io/",
-        organization_id=uuid.uuid4(),
+        base_url=dummy_base_url,
+        organization_id=uuid.UUID(dummy_org_id),
         auth_key="",
     )
     id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"

--- a/tests/agent/actions/test_run_metrics_list_action.py
+++ b/tests/agent/actions/test_run_metrics_list_action.py
@@ -38,6 +38,9 @@ def test_run_metrics_list_computes_metric_run(
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=mock_batch_inspector,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
 
     action._raise_on_any_metric_exception = mocker.Mock()  # type: ignore[method-assign]
@@ -71,6 +74,9 @@ def test_run_metrics_list_computes_metric_run_missing_batch_inspector(
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=None,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
 
     action._raise_on_any_metric_exception = mocker.Mock()  # type: ignore[method-assign]
@@ -102,6 +108,9 @@ def test_run_metrics_list_creates_metric_run(mock_context, mocker: MockerFixture
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=mock_batch_inspector,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
 
     action._raise_on_any_metric_exception = mocker.Mock()  # type: ignore[method-assign]
@@ -132,6 +141,9 @@ def test_run_metrics_list_returns_action_result(mock_context, mocker: MockerFixt
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=mock_batch_inspector,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
     action._raise_on_any_metric_exception = mocker.Mock()  # type: ignore[method-assign]
     # mock so that we don't raise
@@ -170,6 +182,9 @@ def test_run_column_descriptive_metrics_raises_on_test_connection_to_data_asset_
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=mock_batch_inspector,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
 
     with pytest.raises(TestConnectionError):
@@ -223,6 +238,9 @@ def test_run_metrics_list_creates_metric_run_then_raises_on_any_metric_exception
         context=mock_context,
         metric_repository=mock_metric_repository,
         batch_inspector=mock_batch_inspector,
+        base_url="",
+        auth_key="",
+        organization_id=uuid.uuid4(),
     )
 
     with pytest.raises(RuntimeError):

--- a/tests/agent/actions/test_unknown.py
+++ b/tests/agent/actions/test_unknown.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
 from great_expectations_cloud.agent.actions.unknown import UnknownEventAction
@@ -9,6 +11,8 @@ from great_expectations_cloud.agent.models import UnknownEvent
 
 def test_unknown_throws_warning(mocker):
     event = UnknownEvent()
-    action = UnknownEventAction(context=mocker.Mock())
+    action = UnknownEventAction(
+        context=mocker.Mock(), base_url="", auth_key="", organization_id=uuid.uuid4()
+    )
     with pytest.warns(GXAgentUserWarning):
         action.run(event=event, id="lala")

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 
@@ -198,7 +199,12 @@ class TestEventHandlerRegistry:
         register_event_action("0", DummyEvent, DummyAction)  # type: ignore[arg-type]
         handler = EventHandler(context=mock_context)
 
-        assert isinstance(handler.get_event_action(DummyEvent), DummyAction)  # type: ignore[arg-type]  # Dummy event only used in testing
+        assert isinstance(
+            handler.get_event_action(
+                DummyEvent, base_url="", auth_key="", organization_id=uuid.uuid4()
+            ),
+            DummyAction,
+        )  # type: ignore[arg-type]  # Dummy event only used in testing
 
     @pytest.mark.parametrize(
         "version, expected",

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -64,7 +64,9 @@ class TestEventHandler:
         correlation_id = "74842258-803a-48ca-8921-eaf2802c14e2"
         handler = EventHandler(context=mock_context)
         with pytest.warns(GXAgentUserWarning):
-            result = handler.handle_event(event=event, id=correlation_id)
+            result = handler.handle_event(
+                event=event, id=correlation_id, base_url="", auth_key="", organization_id=uuid4()
+            )
         assert result.type == "unknown_event"
 
     @pytest.mark.parametrize(
@@ -137,9 +139,15 @@ class TestEventHandler:
         correlation_id = str(uuid4())
         handler = EventHandler(context=mock_context)
 
-        handler.handle_event(event=event, id=correlation_id)
+        fake_org_id = UUID("00000000-0000-0000-0000-000000000000")
 
-        action.assert_called_with(context=mock_context)
+        handler.handle_event(
+            event=event, id=correlation_id, base_url="", auth_key="", organization_id=fake_org_id
+        )
+
+        action.assert_called_with(
+            context=mock_context, base_url="", organization_id=fake_org_id, auth_key=""
+        )
         action().run.assert_called_with(event=event, id=correlation_id)
 
     def test_event_handler_raises_on_no_version_implementation(
@@ -153,7 +161,7 @@ class TestEventHandler:
         handler = EventHandler(context=mock_context)
 
         with pytest.raises(NoVersionImplementationError):
-            handler.get_event_action(DummyEvent)  # type: ignore[arg-type]  # Dummy event only used in testing
+            handler.get_event_action(DummyEvent, base_url="", auth_key="", organization_id=uuid4())  # type: ignore[arg-type]  # Dummy event only used in testing
 
 
 class DummyEvent(EventBase):

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -201,10 +201,13 @@ class TestEventHandlerRegistry:
 
         assert isinstance(
             handler.get_event_action(
-                DummyEvent, base_url="", auth_key="", organization_id=uuid.uuid4()
+                DummyEvent,  # type: ignore[arg-type]  # Dummy event only used in testing
+                base_url="",
+                auth_key="",
+                organization_id=uuid.uuid4(),
             ),
             DummyAction,
-        )  # type: ignore[arg-type]  # Dummy event only used in testing
+        )
 
     @pytest.mark.parametrize(
         "version, expected",

--- a/tests/integration/actions/test_checkpoint_action.py
+++ b/tests/integration/actions/test_checkpoint_action.py
@@ -211,7 +211,12 @@ def checkpoint_event(checkpoint, datasource_names_to_asset_names, org_id_env_var
 def test_running_checkpoint_action(
     context, checkpoint_event, cloud_base_url: str, org_id_env_var: str, token_env_var: str
 ):
-    action = RunCheckpointAction(context=context)
+    action = RunCheckpointAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=uuid.UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
     event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
     # Act

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -89,12 +89,17 @@ def test_running_draft_datasource_config_action(
 
 
 def test_running_draft_datasource_config_action_fails_for_unreachable_datasource(
-    context: CloudDataContext, org_id_env_var: str
+    context: CloudDataContext, cloud_base_url: str, org_id_env_var: str, token_env_var: str
 ):
     # Arrange
     # Note: Draft config is loaded in mercury seed data
 
-    action = DraftDatasourceConfigAction(context=context)
+    action = DraftDatasourceConfigAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
     datasource_id_for_connect_failure = (
         "e47a5059-a6bb-4de7-9286-6ea600a0c53a"  # local_mercury_db_bad_password
     )

--- a/tests/integration/actions/test_metric_list_action.py
+++ b/tests/integration/actions/test_metric_list_action.py
@@ -116,6 +116,8 @@ def test_running_metric_list_action(
     local_mercury_db_datasource: PostgresDatasource,
     local_mercury_db_organizations_table_asset: TableAsset,
     org_id_env_var: str,
+    cloud_base_url: str,
+    token_env_var: str,
 ):
     # MetricListEvent with only the Table Metrics requested
     metrics_list_event = RunMetricsListEvent(
@@ -130,7 +132,12 @@ def test_running_metric_list_action(
         organization_id=uuid.UUID(org_id_env_var),
     )
 
-    action = MetricListAction(context=context)
+    action = MetricListAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=uuid.UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
     event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
     # Act


### PR DESCRIPTION
Pass in information to each action that is needed to make calls back to cloud. Formerly these were retrieved from env vars but these need to be retrieved differently in the runner vs the agent so are abstracted out into the previously added functions `get_organization_id`, `get_data_context` and base URL is still retrieved from env var.