### PR TITLE
Remove all but standardized version of python in build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10.14"]
     runs-on: ubuntu-latest
 
     steps:
@@ -83,7 +83,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10.14"]
     permissions:
       id-token: write
       contents: read
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.10.14"
           cache-dependency-path: poetry.lock
 
       - name: Load cached Poetry installation
@@ -222,7 +222,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10.14"
           cache-dependency-path: poetry.lock
 
       - name: Load cached Poetry installation
@@ -230,7 +230,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-3.8 # increment to reset cache
+          key: poetry-3.10.14 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -271,7 +271,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10.14"
           cache-dependency-path: poetry.lock
 
       - name: Load cached Poetry installation
@@ -279,7 +279,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-3.8 # increment to reset cache
+          key: poetry-3.10.14 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'


### PR DESCRIPTION
Remove usage of python 3.8 in CI steps and all 3.8, 3.9, and 3.11 testing

## Why
We're only using 3.10.14 in our `docker` image and we're hitting up against GitHub rate limits