### PR TITLE
remove modification of logging args

### DIFF
--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -174,6 +174,17 @@ class JSONFormatter(logging.Formatter):
 
     @override
     def format(self, record: logging.LogRecord) -> str:
+        """
+        Note: args must not be modified to maintain support for fstrings
+        Ex:
+        logger.error(
+            "Snowflake Connector for Python Version: %s, "
+            "Python Version: %s, Platform: %s",
+            SNOWFLAKE_CONNECTOR_VERSION,
+            PYTHON_VERSION,
+            PLATFORM,
+        )
+        """
         log_full = record.__dict__
 
         log_full["event"] = record.msg
@@ -183,9 +194,6 @@ class JSONFormatter(logging.Formatter):
 
         if record.exc_info:
             log_full["exc_info"] = str(record.exc_info)
-
-        if record.args:
-            log_full["args"] = str(record.args)
 
         log_subset = {
             key: value

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -175,8 +175,9 @@ class JSONFormatter(logging.Formatter):
     @override
     def format(self, record: logging.LogRecord) -> str:
         """
-        Note: args must not be modified to maintain support for fstrings
+        TODO Support fstrings substitution containing '%s' syntax
 
+        Example from snowflake-connector-python:
         logger.error(
             "Snowflake Connector for Python Version: %s, "
             "Python Version: %s, Platform: %s",
@@ -184,7 +185,6 @@ class JSONFormatter(logging.Formatter):
             PYTHON_VERSION,
             PLATFORM,
         )
-        TODO Support fstrings substitution containing '%s' syntax
         """
         log_full = record.__dict__
 

--- a/great_expectations_cloud/logging/logging_cfg.py
+++ b/great_expectations_cloud/logging/logging_cfg.py
@@ -176,7 +176,7 @@ class JSONFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         """
         Note: args must not be modified to maintain support for fstrings
-        Ex:
+
         logger.error(
             "Snowflake Connector for Python Version: %s, "
             "Python Version: %s, Platform: %s",
@@ -184,6 +184,7 @@ class JSONFormatter(logging.Formatter):
             PYTHON_VERSION,
             PLATFORM,
         )
+        TODO Support fstrings substitution containing '%s' syntax
         """
         log_full = record.__dict__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240812.0"
+version = "20240812.1.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
The following log uses fstrings:
```
    logger.error(
        "Snowflake Connector for Python Version: %s, "
        "Python Version: %s, Platform: %s",
        SNOWFLAKE_CONNECTOR_VERSION,
        PYTHON_VERSION,
        PLATFORM,
    )
```
and was causing 50 raw logs per execution.

Updated, show args uninterpolated, added TODO for uncommon case
```
{"args": ["3.12.0", "3.10.14", "Linux-5.10.220-209.869.amzn2.x86_64-x86_64-with-glibc2.36"], "levelname": "ERROR", "filename": "cli.py", "module": "cli", "exc_info": null, "stack_info": null, "funcName": "main", "created": 1723489949.485179, "relativeCreated": 2257.412910461426, "event": "Snowflake Connector for Python Version: %s, Python Version: %s, Platform: %s", "level": "ERROR", "logger": "root", "timestamp": "2024-08-12T19:12:29.485179+00:00"}
```