### PR TITLE
[MAINTENANCE] Fix failing test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20240812.1"
+version = "20240814.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -190,8 +190,9 @@ def test_gx_agent_gets_env_vars_on_init(get_context, gx_agent_config, requests_p
 
 
 def test_gx_agent_invalid_token(monkeypatch, set_required_env_vars: None):
-    monkeypatch.setenv("GX_CLOUD_ACCESS_TOKEN", "invalid_token")
-    with pytest.raises(gx_exception.GXCloudError):
+    # There is no validation for the token aside from presence, so we set to empty to raise an error.
+    monkeypatch.setenv("GX_CLOUD_ACCESS_TOKEN", "")
+    with pytest.raises(gx_exception.GXCloudConfigurationError):
         GXAgent()
 
 


### PR DESCRIPTION
`test_gx_agent_invalid_token` was failing because it was actually making an API call instead of failing first.

Since we don't validate the content of the `GX_CLOUD_ACCESS_TOKEN` in Core or the agent/runner then anything we use for the token value would not fail until we try to actually call the backend.

This test now checks that an error is raised if no access token is provided, which fails as expected (with a different exception). I also thought about removing this test but I think there is value in ensuring that we fail if no token is provided.