### PR TITLE
Remove unneeded build-time packages gcc and cpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ COPY examples/agent/data data
 RUN poetry install --only-root && rm -rf POETRY_CACHE_DIR
 
 # Clean up all non-runtime linux deps
-RUN apt-get remove python3-dev gcc -y
+RUN apt-get remove -y \
+    python3-dev \
+    gcc \
+    gcc-12 \
+    cpp-12 \
+    cpp
 
 ENTRYPOINT ["poetry", "run", "gx-agent"]


### PR DESCRIPTION
Removes the `gcc-12`, `cpp-12`, and `cpp` from the image after build steps complete. These are unneeded and `gcc-12` is getting flagged by vulnerability scans.