### PR TITLE
Agent Integration tests - missing tests

### DIFF
--- a/tests/integration/actions/conftest.py
+++ b/tests/integration/actions/conftest.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Iterator
+
+import great_expectations.exceptions as gx_exceptions
+import pandas as pd
+import pytest
+from great_expectations.core import ExpectationConfiguration
+
+if TYPE_CHECKING:
+    from great_expectations.core import ExpectationSuite
+    from great_expectations.data_context import CloudDataContext
+    from great_expectations.datasource.fluent import PandasDatasource
+    from great_expectations.datasource.fluent.pandas_datasource import DataFrameAsset
+
+
+@pytest.fixture(scope="module")
+def pandas_test_df() -> pd.DataFrame:
+    d = {
+        "string": ["a", "b", "c"],
+        "datetime": [
+            pd.to_datetime("2020-01-01"),
+            pd.to_datetime("2020-01-02"),
+            pd.to_datetime("2020-01-03"),
+        ],
+    }
+    df = pd.DataFrame(data=d)
+    return df
+
+
+@pytest.fixture(scope="module")
+def get_missing_datasource_error_type() -> type[Exception]:
+    return ValueError
+
+
+@pytest.fixture(scope="module")
+def get_missing_data_asset_error_type() -> type[Exception]:
+    return LookupError
+
+
+@pytest.fixture(scope="module")
+def in_memory_batch_request_missing_dataframe_error_type() -> type[Exception]:
+    return ValueError
+
+
+@pytest.fixture(scope="module")
+def get_missing_expectation_suite_error_type():
+    return gx_exceptions.DataContextError
+
+
+@pytest.fixture(scope="module")
+def get_missing_checkpoint_error_type():
+    return gx_exceptions.DataContextError
+
+
+@pytest.fixture(scope="module")
+def datasource(
+    context: CloudDataContext,
+    get_missing_datasource_error_type: type[Exception],
+) -> Iterator[PandasDatasource]:
+    datasource_name = f"i{uuid.uuid4().hex}"
+    datasource = context.sources.add_pandas(
+        name=datasource_name,
+    )
+    assert datasource.name == datasource_name
+    datasource_name = f"i{uuid.uuid4().hex}"
+    datasource.name = datasource_name
+    datasource = context.sources.add_or_update_pandas(
+        datasource=datasource,
+    )
+    assert (
+        datasource.name == datasource_name
+    ), "The datasource was not updated in the previous method call."
+    yield datasource
+    context.delete_datasource(datasource_name=datasource_name)
+    with pytest.raises(get_missing_datasource_error_type):
+        context.get_datasource(datasource_name=datasource_name)
+
+
+@pytest.fixture(scope="module")
+def data_asset(
+    datasource: PandasDatasource,
+    get_missing_data_asset_error_type: type[Exception],
+) -> Iterator[DataFrameAsset]:
+    asset_name = f"i{uuid.uuid4().hex}"
+    _ = datasource.add_dataframe_asset(
+        name=asset_name,
+    )
+    data_asset = datasource.get_asset(asset_name=asset_name)
+    yield data_asset
+    datasource.delete_asset(asset_name=asset_name)
+    with pytest.raises(get_missing_data_asset_error_type):
+        datasource.get_asset(asset_name=asset_name)
+
+
+@pytest.fixture(scope="module")
+def batch_request(
+    data_asset: DataFrameAsset,
+    pandas_test_df: pd.DataFrame,
+    in_memory_batch_request_missing_dataframe_error_type: type[Exception],
+):
+    with pytest.raises(in_memory_batch_request_missing_dataframe_error_type):
+        data_asset.build_batch_request()
+    return data_asset.build_batch_request(dataframe=pandas_test_df)
+
+
+@pytest.fixture
+def datasource_names_to_asset_names(datasource, data_asset):
+    return {datasource.name: {data_asset.name}}
+
+
+@pytest.fixture(scope="module")
+def expectation_suite(
+    context: CloudDataContext,
+    data_asset: DataFrameAsset,
+    get_missing_expectation_suite_error_type: type[Exception],
+) -> Iterator[ExpectationSuite]:
+    expectation_suite_name = f"{data_asset.datasource.name} | {data_asset.name}"
+    expectation_suite = context.add_expectation_suite(
+        expectation_suite_name=expectation_suite_name,
+    )
+    expectation_suite.add_expectation(
+        expectation_configuration=ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={
+                "column": "string",
+                "mostly": 1,
+            },
+        )
+    )
+    _ = context.add_or_update_expectation_suite(expectation_suite=expectation_suite)
+    expectation_suite = context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
+    assert (
+        len(expectation_suite.expectations) == 1
+    ), "Expectation Suite was not updated in the previous method call."
+    yield expectation_suite
+    context.delete_expectation_suite(expectation_suite_name=expectation_suite_name)
+    with pytest.raises(get_missing_expectation_suite_error_type):
+        context.get_expectation_suite(expectation_suite_name=expectation_suite_name)

--- a/tests/integration/actions/test_checkpoint_action.py
+++ b/tests/integration/actions/test_checkpoint_action.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Iterator
 
-import great_expectations.exceptions as gx_exceptions
-import pandas as pd
 import pytest
-from great_expectations.core import ExpectationConfiguration
 
 from great_expectations_cloud.agent.models import (
     RunCheckpointEvent,
@@ -16,7 +13,7 @@ if TYPE_CHECKING:
     from great_expectations.checkpoint import Checkpoint
     from great_expectations.core import ExpectationSuite
     from great_expectations.data_context import CloudDataContext
-    from great_expectations.datasource.fluent import BatchRequest, PandasDatasource
+    from great_expectations.datasource.fluent import BatchRequest
     from great_expectations.datasource.fluent.pandas_datasource import DataFrameAsset
 
 
@@ -25,131 +22,6 @@ from great_expectations.core.http import create_session
 from great_expectations_cloud.agent.actions.run_checkpoint import RunCheckpointAction
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture(scope="module")
-def pandas_test_df() -> pd.DataFrame:
-    d = {
-        "string": ["a", "b", "c"],
-        "datetime": [
-            pd.to_datetime("2020-01-01"),
-            pd.to_datetime("2020-01-02"),
-            pd.to_datetime("2020-01-03"),
-        ],
-    }
-    df = pd.DataFrame(data=d)
-    return df
-
-
-@pytest.fixture(scope="module")
-def get_missing_datasource_error_type() -> type[Exception]:
-    return ValueError
-
-
-@pytest.fixture(scope="module")
-def get_missing_data_asset_error_type() -> type[Exception]:
-    return LookupError
-
-
-@pytest.fixture(scope="module")
-def in_memory_batch_request_missing_dataframe_error_type() -> type[Exception]:
-    return ValueError
-
-
-@pytest.fixture(scope="module")
-def get_missing_expectation_suite_error_type():
-    return gx_exceptions.DataContextError
-
-
-@pytest.fixture(scope="module")
-def get_missing_checkpoint_error_type():
-    return gx_exceptions.DataContextError
-
-
-@pytest.fixture(scope="module")
-def datasource(
-    context: CloudDataContext,
-    get_missing_datasource_error_type: type[Exception],
-) -> Iterator[PandasDatasource]:
-    datasource_name = f"i{uuid.uuid4().hex}"
-    datasource = context.sources.add_pandas(
-        name=datasource_name,
-    )
-    assert datasource.name == datasource_name
-    datasource_name = f"i{uuid.uuid4().hex}"
-    datasource.name = datasource_name
-    datasource = context.sources.add_or_update_pandas(
-        datasource=datasource,
-    )
-    assert (
-        datasource.name == datasource_name
-    ), "The datasource was not updated in the previous method call."
-    yield datasource
-    context.delete_datasource(datasource_name=datasource_name)
-    with pytest.raises(get_missing_datasource_error_type):
-        context.get_datasource(datasource_name=datasource_name)
-
-
-@pytest.fixture(scope="module")
-def data_asset(
-    datasource: PandasDatasource,
-    get_missing_data_asset_error_type: type[Exception],
-) -> Iterator[DataFrameAsset]:
-    asset_name = f"i{uuid.uuid4().hex}"
-    _ = datasource.add_dataframe_asset(
-        name=asset_name,
-    )
-    data_asset = datasource.get_asset(asset_name=asset_name)
-    yield data_asset
-    datasource.delete_asset(asset_name=asset_name)
-    with pytest.raises(get_missing_data_asset_error_type):
-        datasource.get_asset(asset_name=asset_name)
-
-
-@pytest.fixture(scope="module")
-def batch_request(
-    data_asset: DataFrameAsset,
-    pandas_test_df: pd.DataFrame,
-    in_memory_batch_request_missing_dataframe_error_type: type[Exception],
-):
-    with pytest.raises(in_memory_batch_request_missing_dataframe_error_type):
-        data_asset.build_batch_request()
-    return data_asset.build_batch_request(dataframe=pandas_test_df)
-
-
-@pytest.fixture
-def datasource_names_to_asset_names(datasource, data_asset):
-    return {datasource.name: {data_asset.name}}
-
-
-@pytest.fixture(scope="module")
-def expectation_suite(
-    context: CloudDataContext,
-    data_asset: DataFrameAsset,
-    get_missing_expectation_suite_error_type: type[Exception],
-) -> Iterator[ExpectationSuite]:
-    expectation_suite_name = f"{data_asset.datasource.name} | {data_asset.name}"
-    expectation_suite = context.add_expectation_suite(
-        expectation_suite_name=expectation_suite_name,
-    )
-    expectation_suite.add_expectation(
-        expectation_configuration=ExpectationConfiguration(
-            expectation_type="expect_column_values_to_not_be_null",
-            kwargs={
-                "column": "string",
-                "mostly": 1,
-            },
-        )
-    )
-    _ = context.add_or_update_expectation_suite(expectation_suite=expectation_suite)
-    expectation_suite = context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
-    assert (
-        len(expectation_suite.expectations) == 1
-    ), "Expectation Suite was not updated in the previous method call."
-    yield expectation_suite
-    context.delete_expectation_suite(expectation_suite_name=expectation_suite_name)
-    with pytest.raises(get_missing_expectation_suite_error_type):
-        context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -39,6 +39,10 @@ def test_running_list_table_names_action(
     )
     event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
+    datasource_id_for_connect_successfully = (
+        "2512c2d8-a212-4295-b01b-2bb2ac066f04"  # local_mercury_db
+    )
+
     expected_table_names = [
         "alembic_version",
         "agent_job_created_resources",
@@ -83,7 +87,7 @@ def test_running_list_table_names_action(
     assert result.created_resources == []
 
     _add_or_update_table_names_list.assert_called_once_with(
-        datasource_id="local_mercury_db", table_names=expected_table_names
+        datasource_id=datasource_id_for_connect_successfully, table_names=expected_table_names
     )
 
 

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -86,8 +86,9 @@ def test_running_list_table_names_action(
     assert result.created_resources == []
 
     # Ensure table name introspection was successful
-    assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
+    # assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
     print("Table names: ", _add_or_update_table_names_list.spy_return)
+    print("Expected table names: ", expected_table_names)
 
 
 def test_running_list_table_names_action_fails_for_unreachable_datasource(

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -23,8 +23,6 @@ def test_running_list_table_names_action(
     mocker: MockerFixture,
 ):
     # Arrange
-    # Note: Draft config is loaded in mercury seed data
-
     action = ListTableNamesAction(
         context=context,
         base_url=cloud_base_url,
@@ -80,7 +78,7 @@ def test_running_list_table_names_action(
     result = action.run(event=list_table_names_event, id=event_id)
 
     # Assert
-    # Check that the action was successful e.g. that we can connect to the datasource
+    # Check that the action was successful e.g. that we can connect to the datasource and list table names
     assert result
     assert result.id == event_id
     assert result.type == list_table_names_event.type
@@ -95,8 +93,6 @@ def test_running_list_table_names_action_fails_for_unreachable_datasource(
     context: CloudDataContext, cloud_base_url: str, org_id_env_var: str, token_env_var: str
 ):
     # Arrange
-    # Note: Draft config is loaded in mercury seed data
-
     action = ListTableNamesAction(
         context=context,
         base_url=cloud_base_url,

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -85,8 +85,9 @@ def test_running_list_table_names_action(
     assert result.type == list_table_names_event.type
     assert result.created_resources == []
 
-    # Ensure table name introspection was successful and that the table names were updated on the draft config
+    # Ensure table name introspection was successful
     assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
+    print("Table names: ", _add_or_update_table_names_list.spy_return)
 
 
 def test_running_list_table_names_action_fails_for_unreachable_datasource(
@@ -110,5 +111,5 @@ def test_running_list_table_names_action_fails_for_unreachable_datasource(
 
     # Act & Assert
     # Check that the action was unsuccessful and an error was raised.
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         action.run(event=list_table_names_event, id=event_id)

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -42,38 +42,38 @@ def test_running_list_table_names_action(
     datasource_id_for_connect_successfully = (
         "2ccfea7f-3f91-47f2-804e-2106aa07ef24"  # local_mercury_db
     )
-
     expected_table_names = [
         "alembic_version",
+        "organization_api_tokens",
+        "asset_refs",
+        "checkpoints",
+        "data_context_variables",
+        "datasources",
+        "expectation_suites",
+        "organizations",
+        "api_tokens",
+        "users",
         "agent_job_created_resources",
         "agent_job_source_resources",
+        "draft_configs",
+        "metric_runs",
+        "metrics",
         "agent_jobs",
-        "asset_refs",
         "expectations",
         "expectation_changes",
-        "checkpoint_job_schedules",
-        "draft_configs",
-        "user_api_tokens",
-        "user_asset_alerts",
-        "organization_api_tokens",
-        "suite_validation_results",
-        "metrics",
-        "batch_definitions",
-        "expectation_suites",
-        "expectation_validation_results",
-        "data_context_variables",
         "system_users",
-        "checkpoints",
-        "organizations",
-        "metric_runs",
-        "users",
+        "batch_definitions",
+        "checkpoint_job_schedules",
+        "expectation_validation_results",
+        "suite_validation_results",
+        "user_api_tokens",
         "auth0_users",
-        "datasources",
         "organization_users",
+        "user_asset_alerts",
         "validations",
-        "api_tokens",
     ]
-    # add spies to the action methods
+
+    # add spy to the action method
     _add_or_update_table_names_list = mocker.spy(action, "_add_or_update_table_names_list")
 
     # Act

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -82,12 +82,9 @@ def test_running_list_table_names_action(
     assert result.type == list_table_names_event.type
     assert result.created_resources == []
 
-    # Ensure table name introspection was successful
-    # assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
-    print("Result:", result)
-    print("Table names: ", _add_or_update_table_names_list.spy_return)
-    print("Expected table names: ", expected_table_names)
-    assert False
+    _add_or_update_table_names_list.assert_called_once_with(
+        datasource_id="local_mercury_db", table_names=expected_table_names
+    )
 
 
 def test_running_list_table_names_action_fails_for_unreachable_datasource(

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -40,7 +40,7 @@ def test_running_list_table_names_action(
     event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
 
     datasource_id_for_connect_successfully = (
-        "2512c2d8-a212-4295-b01b-2bb2ac066f04"  # local_mercury_db
+        "2ccfea7f-3f91-47f2-804e-2106aa07ef24"  # local_mercury_db
     )
 
     expected_table_names = [

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -6,7 +6,6 @@ from uuid import UUID
 import pytest
 
 from great_expectations_cloud.agent.actions import ListTableNamesAction
-from great_expectations_cloud.agent.exceptions import GXCoreError
 from great_expectations_cloud.agent.models import ListTableNamesEvent
 
 if TYPE_CHECKING:
@@ -74,8 +73,7 @@ def test_running_list_table_names_action(
         "api_tokens",
     ]
     # add spies to the action methods
-    _get_table_names_spy = mocker.spy(action, "_get_table_names")
-    _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
+    _add_or_update_table_names_list = mocker.spy(action, "_add_or_update_table_names_list")
 
     # Act
     result = action.run(event=list_table_names_event, id=event_id)
@@ -88,15 +86,7 @@ def test_running_list_table_names_action(
     assert result.created_resources == []
 
     # Ensure table name introspection was successful and that the table names were updated on the draft config
-    assert sorted(_get_table_names_spy.spy_return) == sorted(expected_table_names)
-
-    # assert _update_table_names_list was called with the correct arguments
-    # assert _update_table_names_list_spy.call_args.kwargs.get("config_id") == UUID(
-    #     draft_datasource_id_for_connect_successfully
-    # )
-    assert sorted(_update_table_names_list_spy.call_args.kwargs.get("table_names")) == sorted(
-        expected_table_names
-    )
+    assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
 
 
 def test_running_list_table_names_action_fails_for_unreachable_datasource(
@@ -120,5 +110,5 @@ def test_running_list_table_names_action_fails_for_unreachable_datasource(
 
     # Act & Assert
     # Check that the action was unsuccessful and an error was raised.
-    with pytest.raises(GXCoreError):
+    with pytest.raises(KeyError):
         action.run(event=list_table_names_event, id=event_id)

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -32,9 +32,6 @@ def test_running_list_table_names_action(
         auth_key=token_env_var,
     )
 
-    # datasource_id_for_connect_successfully = (
-    #     "2512c2d8-a212-4295-b01b-2bb2ac066f04"  # local_mercury_db
-    # )
     list_table_names_event = ListTableNamesEvent(
         type="list_table_names_request.received",
         datasource_name="local_mercury_db",
@@ -87,6 +84,7 @@ def test_running_list_table_names_action(
 
     # Ensure table name introspection was successful
     # assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
+    print("Result:", result)
     print("Table names: ", _add_or_update_table_names_list.spy_return)
     print("Expected table names: ", expected_table_names)
     assert False

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -89,6 +89,7 @@ def test_running_list_table_names_action(
     # assert sorted(_add_or_update_table_names_list.spy_return) == sorted(expected_table_names)
     print("Table names: ", _add_or_update_table_names_list.spy_return)
     print("Expected table names: ", expected_table_names)
+    assert False
 
 
 def test_running_list_table_names_action_fails_for_unreachable_datasource(

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+
+from great_expectations_cloud.agent.actions import DraftDatasourceConfigAction
+from great_expectations_cloud.agent.exceptions import GXCoreError
+from great_expectations_cloud.agent.models import DraftDatasourceConfigEvent
+
+if TYPE_CHECKING:
+    from great_expectations.data_context import CloudDataContext
+    from pytest_mock import MockerFixture
+
+pytestmark = pytest.mark.integration
+
+
+def test_running_draft_datasource_config_action(
+    context: CloudDataContext,
+    cloud_base_url: str,
+    org_id_env_var: str,
+    token_env_var: str,
+    mocker: MockerFixture,
+):
+    # Arrange
+    # Note: Draft config is loaded in mercury seed data
+
+    action = DraftDatasourceConfigAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
+
+    draft_datasource_id_for_connect_successfully = (
+        "2512c2d8-a212-4295-b01b-2bb2ac066f04"  # local_mercury_db
+    )
+    list_table_names_event = DraftDatasourceConfigEvent(
+        type="test_datasource_config",
+        config_id=UUID(draft_datasource_id_for_connect_successfully),
+        organization_id=UUID(org_id_env_var),
+    )
+    event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
+
+    expected_table_names = [
+        "alembic_version",
+        "agent_job_created_resources",
+        "agent_job_source_resources",
+        "agent_jobs",
+        "asset_refs",
+        "expectations",
+        "expectation_changes",
+        "checkpoint_job_schedules",
+        "draft_configs",
+        "user_api_tokens",
+        "user_asset_alerts",
+        "organization_api_tokens",
+        "suite_validation_results",
+        "metrics",
+        "batch_definitions",
+        "expectation_suites",
+        "expectation_validation_results",
+        "data_context_variables",
+        "system_users",
+        "checkpoints",
+        "organizations",
+        "metric_runs",
+        "users",
+        "auth0_users",
+        "datasources",
+        "organization_users",
+        "validations",
+        "api_tokens",
+    ]
+    # add spies to the action methods
+    _get_table_names_spy = mocker.spy(action, "_get_table_names")
+    _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
+
+    # Act
+    result = action.run(event=list_table_names_event, id=event_id)
+
+    # Assert
+    # Check that the action was successful e.g. that we can connect to the datasource
+    assert result
+    assert result.id == event_id
+    assert result.type == list_table_names_event.type
+    assert result.created_resources == []
+
+    # Ensure table name introspection was successful and that the table names were updated on the draft config
+    assert sorted(_get_table_names_spy.spy_return) == sorted(expected_table_names)
+
+    # assert _update_table_names_list was called with the correct arguments
+    assert _update_table_names_list_spy.call_args.kwargs.get("config_id") == UUID(
+        draft_datasource_id_for_connect_successfully
+    )
+    assert sorted(_update_table_names_list_spy.call_args.kwargs.get("table_names")) == sorted(
+        expected_table_names
+    )
+
+
+def test_running_draft_datasource_config_action_fails_for_unreachable_datasource(
+    context: CloudDataContext, cloud_base_url: str, org_id_env_var: str, token_env_var: str
+):
+    # Arrange
+    # Note: Draft config is loaded in mercury seed data
+
+    action = DraftDatasourceConfigAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
+    datasource_id_for_connect_failure = (
+        "e47a5059-a6bb-4de7-9286-6ea600a0c53a"  # local_mercury_db_bad_password
+    )
+    draft_datasource_config_event = DraftDatasourceConfigEvent(
+        type="test_datasource_config",
+        config_id=UUID(datasource_id_for_connect_failure),
+        organization_id=UUID(org_id_env_var),
+    )
+    event_id = "64842838-c7bf-4038-8b27-c7a32eba4b7b"
+
+    # Act & Assert
+    # Check that the action was unsuccessful and an error was raised.
+    with pytest.raises(GXCoreError):
+        action.run(event=draft_datasource_config_event, id=event_id)

--- a/tests/integration/actions/test_run_scheduled_checkpoint.py
+++ b/tests/integration/actions/test_run_scheduled_checkpoint.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Iterator
+
+import great_expectations.exceptions as gx_exceptions
+import pandas as pd
+import pytest
+from great_expectations.core import ExpectationConfiguration
+
+from great_expectations_cloud.agent.models import (
+    RunScheduledCheckpointEvent,
+)
+
+if TYPE_CHECKING:
+    from great_expectations.checkpoint import Checkpoint
+    from great_expectations.core import ExpectationSuite
+    from great_expectations.data_context import CloudDataContext
+    from great_expectations.datasource.fluent import BatchRequest, PandasDatasource
+    from great_expectations.datasource.fluent.pandas_datasource import DataFrameAsset
+
+
+from great_expectations.core.http import create_session
+
+from great_expectations_cloud.agent.actions.run_scheduled_checkpoint import (
+    RunScheduledCheckpointAction,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def pandas_test_df() -> pd.DataFrame:
+    d = {
+        "string": ["a", "b", "c"],
+        "datetime": [
+            pd.to_datetime("2020-01-01"),
+            pd.to_datetime("2020-01-02"),
+            pd.to_datetime("2020-01-03"),
+        ],
+    }
+    df = pd.DataFrame(data=d)
+    return df
+
+
+@pytest.fixture(scope="module")
+def get_missing_datasource_error_type() -> type[Exception]:
+    return ValueError
+
+
+@pytest.fixture(scope="module")
+def get_missing_data_asset_error_type() -> type[Exception]:
+    return LookupError
+
+
+@pytest.fixture(scope="module")
+def in_memory_batch_request_missing_dataframe_error_type() -> type[Exception]:
+    return ValueError
+
+
+@pytest.fixture(scope="module")
+def get_missing_expectation_suite_error_type():
+    return gx_exceptions.DataContextError
+
+
+@pytest.fixture(scope="module")
+def get_missing_checkpoint_error_type():
+    return gx_exceptions.DataContextError
+
+
+@pytest.fixture(scope="module")
+def datasource(
+    context: CloudDataContext,
+    get_missing_datasource_error_type: type[Exception],
+) -> Iterator[PandasDatasource]:
+    datasource_name = f"i{uuid.uuid4().hex}"
+    datasource = context.sources.add_pandas(
+        name=datasource_name,
+    )
+    assert datasource.name == datasource_name
+    datasource_name = f"i{uuid.uuid4().hex}"
+    datasource.name = datasource_name
+    datasource = context.sources.add_or_update_pandas(
+        datasource=datasource,
+    )
+    assert (
+        datasource.name == datasource_name
+    ), "The datasource was not updated in the previous method call."
+    yield datasource
+    context.delete_datasource(datasource_name=datasource_name)
+    with pytest.raises(get_missing_datasource_error_type):
+        context.get_datasource(datasource_name=datasource_name)
+
+
+@pytest.fixture(scope="module")
+def data_asset(
+    datasource: PandasDatasource,
+    get_missing_data_asset_error_type: type[Exception],
+) -> Iterator[DataFrameAsset]:
+    asset_name = f"i{uuid.uuid4().hex}"
+    _ = datasource.add_dataframe_asset(
+        name=asset_name,
+    )
+    data_asset = datasource.get_asset(asset_name=asset_name)
+    yield data_asset
+    datasource.delete_asset(asset_name=asset_name)
+    with pytest.raises(get_missing_data_asset_error_type):
+        datasource.get_asset(asset_name=asset_name)
+
+
+@pytest.fixture(scope="module")
+def batch_request(
+    data_asset: DataFrameAsset,
+    pandas_test_df: pd.DataFrame,
+    in_memory_batch_request_missing_dataframe_error_type: type[Exception],
+):
+    with pytest.raises(in_memory_batch_request_missing_dataframe_error_type):
+        data_asset.build_batch_request()
+    return data_asset.build_batch_request(dataframe=pandas_test_df)
+
+
+@pytest.fixture
+def datasource_names_to_asset_names(datasource, data_asset):
+    return {datasource.name: {data_asset.name}}
+
+
+@pytest.fixture(scope="module")
+def expectation_suite(
+    context: CloudDataContext,
+    data_asset: DataFrameAsset,
+    get_missing_expectation_suite_error_type: type[Exception],
+) -> Iterator[ExpectationSuite]:
+    expectation_suite_name = f"{data_asset.datasource.name} | {data_asset.name}"
+    expectation_suite = context.add_expectation_suite(
+        expectation_suite_name=expectation_suite_name,
+    )
+    expectation_suite.add_expectation(
+        expectation_configuration=ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={
+                "column": "string",
+                "mostly": 1,
+            },
+        )
+    )
+    _ = context.add_or_update_expectation_suite(expectation_suite=expectation_suite)
+    expectation_suite = context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
+    assert (
+        len(expectation_suite.expectations) == 1
+    ), "Expectation Suite was not updated in the previous method call."
+    yield expectation_suite
+    context.delete_expectation_suite(expectation_suite_name=expectation_suite_name)
+    with pytest.raises(get_missing_expectation_suite_error_type):
+        context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
+
+
+@pytest.fixture(scope="module")
+def scheduled_checkpoint(
+    context: CloudDataContext,
+    data_asset: DataFrameAsset,
+    batch_request: BatchRequest,
+    expectation_suite: ExpectationSuite,
+    get_missing_checkpoint_error_type: type[Exception],
+) -> Iterator[Checkpoint]:
+    checkpoint_name = f"{data_asset.datasource.name} | {data_asset.name}"
+    _ = context.add_checkpoint(
+        name=checkpoint_name,
+        validations=[
+            {
+                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "batch_request": batch_request,
+            },
+            {
+                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "batch_request": batch_request,
+            },
+        ],
+    )
+    _ = context.add_or_update_checkpoint(
+        name=checkpoint_name,
+        validations=[
+            {
+                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "batch_request": batch_request,
+            }
+        ],
+    )
+    checkpoint = context.get_checkpoint(name=checkpoint_name)
+    assert (
+        len(checkpoint.validations) == 1
+    ), "Checkpoint was not updated in the previous method call."
+    yield checkpoint
+    # PP-691: this is a bug
+    # you should only have to pass name
+    context.delete_checkpoint(
+        # name=checkpoint_name,
+        id=checkpoint.ge_cloud_id,
+    )
+    with pytest.raises(get_missing_checkpoint_error_type):
+        context.get_checkpoint(name=checkpoint_name)
+
+
+@pytest.fixture
+def checkpoint_event(checkpoint, datasource_names_to_asset_names, org_id_env_var: str):
+    return RunScheduledCheckpointEvent(
+        type="run_scheduled_checkpoint.received",
+        checkpoint_id=checkpoint.ge_cloud_id,
+        datasource_names_to_asset_names=datasource_names_to_asset_names,
+        organization_id=uuid.UUID(org_id_env_var),
+    )
+
+
+def test_running_checkpoint_action(
+    context, checkpoint_event, cloud_base_url: str, org_id_env_var: str, token_env_var: str
+):
+    action = RunScheduledCheckpointAction(
+        context=context,
+        base_url=cloud_base_url,
+        organization_id=uuid.UUID(org_id_env_var),
+        auth_key=token_env_var,
+    )
+    event_id = "096ce840-7aa8-45d1-9e64-2833948f4ae8"
+
+    # Act
+    action_result = action.run(event=checkpoint_event, id=event_id)
+
+    # Assert
+    # Check that the action was successful, and we have received correct checkpoint event.
+    assert action_result.type == checkpoint_event.type
+    assert action_result.id == event_id
+
+    # Check that the checkpoint was successful by querying the DB.
+    validation_result_id = action_result.created_resources[0].resource_id
+    resource_url = (
+        f"{cloud_base_url}/organizations/"
+        f"{org_id_env_var}/validation-results/{validation_result_id}"
+    )
+    with create_session(access_token=token_env_var) as session:
+        response = session.get(resource_url)
+        data = response.json()
+
+    validation_result = data["data"]["attributes"]["validation_result"]
+    assert validation_result["success"]

--- a/tests/integration/actions/test_run_scheduled_checkpoint.py
+++ b/tests/integration/actions/test_run_scheduled_checkpoint.py
@@ -205,6 +205,7 @@ def checkpoint_event(checkpoint, datasource_names_to_asset_names, org_id_env_var
     return RunScheduledCheckpointEvent(
         type="run_scheduled_checkpoint.received",
         checkpoint_id=checkpoint.ge_cloud_id,
+        schedule_id=uuid.UUID("e37cc13f-141d-4818-93c2-e3ec60024683"),
         datasource_names_to_asset_names=datasource_names_to_asset_names,
         organization_id=uuid.UUID(org_id_env_var),
     )

--- a/tests/integration/actions/test_run_scheduled_checkpoint.py
+++ b/tests/integration/actions/test_run_scheduled_checkpoint.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Iterator
 
-import great_expectations.exceptions as gx_exceptions
-import pandas as pd
 import pytest
-from great_expectations.core import ExpectationConfiguration
 
 from great_expectations_cloud.agent.models import (
     RunScheduledCheckpointEvent,
@@ -16,7 +13,7 @@ if TYPE_CHECKING:
     from great_expectations.checkpoint import Checkpoint
     from great_expectations.core import ExpectationSuite
     from great_expectations.data_context import CloudDataContext
-    from great_expectations.datasource.fluent import BatchRequest, PandasDatasource
+    from great_expectations.datasource.fluent import BatchRequest
     from great_expectations.datasource.fluent.pandas_datasource import DataFrameAsset
 
 
@@ -27,131 +24,6 @@ from great_expectations_cloud.agent.actions.run_scheduled_checkpoint import (
 )
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture(scope="module")
-def pandas_test_df() -> pd.DataFrame:
-    d = {
-        "string": ["a", "b", "c"],
-        "datetime": [
-            pd.to_datetime("2020-01-01"),
-            pd.to_datetime("2020-01-02"),
-            pd.to_datetime("2020-01-03"),
-        ],
-    }
-    df = pd.DataFrame(data=d)
-    return df
-
-
-@pytest.fixture(scope="module")
-def get_missing_datasource_error_type() -> type[Exception]:
-    return ValueError
-
-
-@pytest.fixture(scope="module")
-def get_missing_data_asset_error_type() -> type[Exception]:
-    return LookupError
-
-
-@pytest.fixture(scope="module")
-def in_memory_batch_request_missing_dataframe_error_type() -> type[Exception]:
-    return ValueError
-
-
-@pytest.fixture(scope="module")
-def get_missing_expectation_suite_error_type():
-    return gx_exceptions.DataContextError
-
-
-@pytest.fixture(scope="module")
-def get_missing_checkpoint_error_type():
-    return gx_exceptions.DataContextError
-
-
-@pytest.fixture(scope="module")
-def datasource(
-    context: CloudDataContext,
-    get_missing_datasource_error_type: type[Exception],
-) -> Iterator[PandasDatasource]:
-    datasource_name = f"i{uuid.uuid4().hex}"
-    datasource = context.sources.add_pandas(
-        name=datasource_name,
-    )
-    assert datasource.name == datasource_name
-    datasource_name = f"i{uuid.uuid4().hex}"
-    datasource.name = datasource_name
-    datasource = context.sources.add_or_update_pandas(
-        datasource=datasource,
-    )
-    assert (
-        datasource.name == datasource_name
-    ), "The datasource was not updated in the previous method call."
-    yield datasource
-    context.delete_datasource(datasource_name=datasource_name)
-    with pytest.raises(get_missing_datasource_error_type):
-        context.get_datasource(datasource_name=datasource_name)
-
-
-@pytest.fixture(scope="module")
-def data_asset(
-    datasource: PandasDatasource,
-    get_missing_data_asset_error_type: type[Exception],
-) -> Iterator[DataFrameAsset]:
-    asset_name = f"i{uuid.uuid4().hex}"
-    _ = datasource.add_dataframe_asset(
-        name=asset_name,
-    )
-    data_asset = datasource.get_asset(asset_name=asset_name)
-    yield data_asset
-    datasource.delete_asset(asset_name=asset_name)
-    with pytest.raises(get_missing_data_asset_error_type):
-        datasource.get_asset(asset_name=asset_name)
-
-
-@pytest.fixture(scope="module")
-def batch_request(
-    data_asset: DataFrameAsset,
-    pandas_test_df: pd.DataFrame,
-    in_memory_batch_request_missing_dataframe_error_type: type[Exception],
-):
-    with pytest.raises(in_memory_batch_request_missing_dataframe_error_type):
-        data_asset.build_batch_request()
-    return data_asset.build_batch_request(dataframe=pandas_test_df)
-
-
-@pytest.fixture
-def datasource_names_to_asset_names(datasource, data_asset):
-    return {datasource.name: {data_asset.name}}
-
-
-@pytest.fixture(scope="module")
-def expectation_suite(
-    context: CloudDataContext,
-    data_asset: DataFrameAsset,
-    get_missing_expectation_suite_error_type: type[Exception],
-) -> Iterator[ExpectationSuite]:
-    expectation_suite_name = f"{data_asset.datasource.name} | {data_asset.name}"
-    expectation_suite = context.add_expectation_suite(
-        expectation_suite_name=expectation_suite_name,
-    )
-    expectation_suite.add_expectation(
-        expectation_configuration=ExpectationConfiguration(
-            expectation_type="expect_column_values_to_not_be_null",
-            kwargs={
-                "column": "string",
-                "mostly": 1,
-            },
-        )
-    )
-    _ = context.add_or_update_expectation_suite(expectation_suite=expectation_suite)
-    expectation_suite = context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
-    assert (
-        len(expectation_suite.expectations) == 1
-    ), "Expectation Suite was not updated in the previous method call."
-    yield expectation_suite
-    context.delete_expectation_suite(expectation_suite_name=expectation_suite_name)
-    with pytest.raises(get_missing_expectation_suite_error_type):
-        context.get_expectation_suite(expectation_suite_name=expectation_suite_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/actions/test_run_scheduled_checkpoint.py
+++ b/tests/integration/actions/test_run_scheduled_checkpoint.py
@@ -201,10 +201,10 @@ def scheduled_checkpoint(
 
 
 @pytest.fixture
-def checkpoint_event(checkpoint, datasource_names_to_asset_names, org_id_env_var: str):
+def checkpoint_event(scheduled_checkpoint, datasource_names_to_asset_names, org_id_env_var: str):
     return RunScheduledCheckpointEvent(
         type="run_scheduled_checkpoint.received",
-        checkpoint_id=checkpoint.ge_cloud_id,
+        checkpoint_id=scheduled_checkpoint.ge_cloud_id,
         schedule_id=uuid.UUID("e37cc13f-141d-4818-93c2-e3ec60024683"),
         datasource_names_to_asset_names=datasource_names_to_asset_names,
         organization_id=uuid.UUID(org_id_env_var),

--- a/tests/integration/actions/test_run_window_checkpoint.py
+++ b/tests/integration/actions/test_run_window_checkpoint.py
@@ -1,0 +1,6 @@
+# this is currently a stub as we continue the work on Window Checkpoints
+from __future__ import annotations
+
+
+def test_running_window_checkpoint_action():
+    pass


### PR DESCRIPTION
A few agent `Actions` were missing integration tests, and this PR adds them. For ones that use common fixtures, they were moved to a shared `conftest.py` file. 

* `ListTableNamesAction`
* `RunScheduledCheckpointAction`
* `RunWindowCheckpointAction` (just a stub was added)