### PR TITLE
Run Window Checkpoint v0 version

### DIFF
--- a/great_expectations_cloud/agent/actions/__init__.py
+++ b/great_expectations_cloud/agent/actions/__init__.py
@@ -16,3 +16,4 @@ from great_expectations_cloud.agent.actions.run_metric_list_action import Metric
 from great_expectations_cloud.agent.actions.run_scheduled_checkpoint import (
     RunScheduledCheckpointAction,
 )
+from great_expectations_cloud.agent.actions.run_window_checkpoint import RunWindowCheckpointAction

--- a/great_expectations_cloud/agent/actions/run_scheduled_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_scheduled_checkpoint.py
@@ -6,7 +6,7 @@ from great_expectations_cloud.agent.actions.agent_action import (
     ActionResult,
     AgentAction,
 )
-from great_expectations_cloud.agent.actions.run_checkpoint import run_checkpoint
+from great_expectations_cloud.agent.actions.run_checkpoint import run_checkpoint_v0
 from great_expectations_cloud.agent.event_handler import register_event_action
 from great_expectations_cloud.agent.models import (
     RunScheduledCheckpointEvent,
@@ -19,7 +19,7 @@ class RunScheduledCheckpointAction(AgentAction[RunScheduledCheckpointEvent]):
 
     @override
     def run(self, event: RunScheduledCheckpointEvent, id: str) -> ActionResult:
-        return run_checkpoint(self._context, event, id)
+        return run_checkpoint_v0(self._context, event, id)
 
 
 register_event_action("0", RunScheduledCheckpointEvent, RunScheduledCheckpointAction)

--- a/great_expectations_cloud/agent/actions/run_window_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_window_checkpoint.py
@@ -22,7 +22,7 @@ class RunWindowCheckpointAction(AgentAction[RunWindowCheckpointEvent]):
     @override
     def run(self, event: RunWindowCheckpointEvent, id: str) -> ActionResult:
         with create_session(access_token=self._auth_key) as session:
-            expectation_parameters_for_checkpoint_url = f"{self._base_url}api/v1/organizations/"
+            expectation_parameters_for_checkpoint_url = f"{self._base_url}/api/v1/organizations/"
             f"{self._organization_id}/checkpoints/{event.checkpoint_id}/expectation-parameters"
             response = session.get(url=expectation_parameters_for_checkpoint_url)
 

--- a/great_expectations_cloud/agent/actions/run_window_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_window_checkpoint.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from great_expectations.core.http import create_session
+from great_expectations.exceptions import GXCloudError
 from typing_extensions import override
 
 from great_expectations_cloud.agent.actions.agent_action import (
     ActionResult,
     AgentAction,
 )
-from great_expectations_cloud.agent.actions.run_checkpoint import run_checkpoint
+from great_expectations_cloud.agent.actions.run_checkpoint import run_checkpoint_v0
 from great_expectations_cloud.agent.event_handler import register_event_action
 from great_expectations_cloud.agent.models import (
     RunWindowCheckpointEvent,
@@ -19,9 +21,30 @@ class RunWindowCheckpointAction(AgentAction[RunWindowCheckpointEvent]):
 
     @override
     def run(self, event: RunWindowCheckpointEvent, id: str) -> ActionResult:
-        # TODO: https://greatexpectations.atlassian.net/browse/ZELDA-922
-        #  This currently only runs a normal checkpoint. Logic for window checkpoints needs to be added (e.g. call the backend to get the params and then construct the evaluation_parameters before passing them into context.run_checkpoint()) One way we can do this via a param in `run_checkpoint()` that takes a function to build the evaluation_parameters, defaulting to a noop for the other checkpoint action types.
-        return run_checkpoint(self._context, event, id)
+        with create_session(access_token=self._auth_key) as session:
+            expectation_parameters_for_checkpoint_url = f"{self._base_url}api/v1/organizations/"
+            f"{self._organization_id}/checkpoints/{event.checkpoint_id}/expectation-parameters"
+            response = session.get(url=expectation_parameters_for_checkpoint_url)
+
+        if not response.ok:
+            raise GXCloudError(
+                message=f"RunWindowCheckpointAction encountered an error while connecting to GX Cloud. "
+                f"Unable to retrieve expectation_parameters for Checkpoint with ID={event.checkpoint_id}.",
+                response=response,
+            )
+        data = response.json()
+        try:
+            expectation_parameters = data["data"]["expectation_parameters"]
+        except KeyError as e:
+            raise GXCloudError(
+                message="Malformed response received from GX Cloud",
+                response=response,
+            ) from e
+
+        # Note: In v0 expectation_parameters are called evaluation_parameters.
+        return run_checkpoint_v0(
+            self._context, event, id, evaluation_parameters=expectation_parameters
+        )
 
 
 register_event_action("0", RunWindowCheckpointEvent, RunWindowCheckpointAction)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241002.0.dev0"
+version = "20241002.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
WIP - No tests are added yet. This PR likely won't get merged, instead we will merge a v1 action. Rather than write tests, if we are not using the v0 version & don't merge this PR we can just use it for internal testing of the feature.

See https://greatexpectations.atlassian.net/browse/ZELDA-959 for the Jira for the checkpoint v1 action. Once that is complete we can implement a similar workflow based on the v1 run checkpoint flow: https://docs.greatexpectations.io/docs/core/trigger_actions_based_on_results/run_a_checkpoint