### PR TITLE
Integrate with mercury fastapi endpoints

### DIFF
--- a/great_expectations_cloud/agent/actions/run_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_checkpoint.py
@@ -41,14 +41,14 @@ def run_checkpoint(
     """Note: the logic for this action is broken out into this function so that
     the same logic can be used for both RunCheckpointEvent and RunScheduledCheckpointEvent."""
 
-    # the checkpoint_name property on events is optional for backwards compatibility,
+    # the checkpoint_name property on possible events is optional for backwards compatibility,
     # but this action requires it in order to run:
     if not event.checkpoint_name:
         raise MissingCheckpointNameError
 
     # test connection to data source and any assets used by checkpoint
     for datasource_name, data_asset_names in event.datasource_names_to_asset_names.items():
-        datasource = context.get_datasource(datasource_name)
+        datasource = context.data_sources.get(name=datasource_name)
         datasource.test_connection(test_assets=False)  # raises `TestConnectionError` on failure
         for (
             data_asset_name

--- a/great_expectations_cloud/agent/actions/run_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_checkpoint.py
@@ -21,9 +21,6 @@ if TYPE_CHECKING:
 
 
 class RunCheckpointAction(AgentAction[RunCheckpointEvent]):
-    # TODO: New actions need to be created that are compatible with GX v1 and registered for v1.
-    #  This action is registered for v0, see register_event_action()
-
     @override
     def run(self, event: RunCheckpointEvent, id: str) -> ActionResult:
         return run_checkpoint(self._context, event, id)

--- a/great_expectations_cloud/agent/actions/run_scheduled_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_scheduled_checkpoint.py
@@ -14,12 +14,9 @@ from great_expectations_cloud.agent.models import (
 
 
 class RunScheduledCheckpointAction(AgentAction[RunScheduledCheckpointEvent]):
-    # TODO: New actions need to be created that are compatible with GX v1 and registered for v1.
-    #  This action is registered for v0, see register_event_action()
-
     @override
     def run(self, event: RunScheduledCheckpointEvent, id: str) -> ActionResult:
         return run_checkpoint(self._context, event, id)
 
 
-register_event_action("0", RunScheduledCheckpointEvent, RunScheduledCheckpointAction)
+register_event_action("1", RunScheduledCheckpointEvent, RunScheduledCheckpointAction)

--- a/great_expectations_cloud/agent/actions/run_window_checkpoint.py
+++ b/great_expectations_cloud/agent/actions/run_window_checkpoint.py
@@ -14,9 +14,6 @@ from great_expectations_cloud.agent.models import (
 
 
 class RunWindowCheckpointAction(AgentAction[RunWindowCheckpointEvent]):
-    # TODO: New actions need to be created that are compatible with GX v1 and registered for v1.
-    #  This action is registered for v0, see register_event_action()
-
     @override
     def run(self, event: RunWindowCheckpointEvent, id: str) -> ActionResult:
         # TODO: https://greatexpectations.atlassian.net/browse/ZELDA-922
@@ -24,4 +21,4 @@ class RunWindowCheckpointAction(AgentAction[RunWindowCheckpointEvent]):
         return run_checkpoint(self._context, event, id)
 
 
-register_event_action("0", RunWindowCheckpointEvent, RunWindowCheckpointAction)
+register_event_action("1", RunWindowCheckpointEvent, RunWindowCheckpointAction)

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -388,7 +388,7 @@ class GXAgent:
 
         # obtain the broker url and queue name from Cloud
         agent_sessions_url = (
-            f"{env_vars.gx_cloud_base_url}/organizations/"
+            f"{env_vars.gx_cloud_base_url}/api/v1/organizations/"
             f"{env_vars.gx_cloud_organization_id}/agent-sessions"
         )
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -47,6 +47,7 @@ from great_expectations_cloud.agent.models import (
     JobStatus,
     ScheduledEventBase,
     UnknownEvent,
+    UpdateJobStatusRequest,
     build_failed_job_completed_status,
 )
 
@@ -430,10 +431,11 @@ class GXAgent:
             extra={"job_id": job_id, "status": str(status), "organization_id": str(org_id)},
         )
         agent_sessions_url = (
-            f"{self._config.gx_cloud_base_url}/organizations/{org_id}" + f"/agent-jobs/{job_id}"
+            f"{self._config.gx_cloud_base_url}/api/v1/organizations/{org_id}"
+            + f"/agent-jobs/{job_id}"
         )
         with create_session(access_token=self.get_auth_key()) as session:
-            data = status.json()
+            data = UpdateJobStatusRequest(data=status).json()
             session.patch(agent_sessions_url, data=data)
             LOGGER.info(
                 "Status updated",
@@ -462,7 +464,7 @@ class GXAgent:
         )
 
         agent_sessions_url = (
-            f"{self._config.gx_cloud_base_url}/organizations/{org_id}" + "/agent-jobs"
+            f"{self._config.gx_cloud_base_url}/api/v1/organizations/{org_id}" + "/agent-jobs"
         )
         with create_session(access_token=self.get_auth_key()) as session:
             payload = Payload(data=data)

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -146,6 +146,10 @@ class JobCompleted(AgentBaseExtraForbid):
 JobStatus = Union[JobStarted, JobCompleted]
 
 
+class UpdateJobStatusRequest(AgentBaseExtraForbid):
+    data: JobStatus
+
+
 def build_failed_job_completed_status(error: BaseException) -> JobCompleted:
     if isinstance(error, GXCoreError):
         status = JobCompleted(

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -33,6 +33,7 @@ from great_expectations_cloud.agent.models import (
     JobStarted,
     RunOnboardingDataAssistantEvent,
     RunScheduledCheckpointEvent,
+    UpdateJobStatusRequest,
 )
 from tests.agent.conftest import DummyEvent, FakeMessagePayload, FakeSubscriber
 
@@ -281,11 +282,13 @@ def test_gx_agent_updates_cloud_on_job_status(
 ):
     correlation_id = "4ae63677-4dd5-4fb0-b511-870e7a286e77"
     url = (
-        f"{gx_agent_config.gx_cloud_base_url}/organizations/"
+        f"{gx_agent_config.gx_cloud_base_url}/api/v1/organizations/"
         f"{gx_agent_config.gx_cloud_organization_id}/agent-jobs/{correlation_id}"
     )
-    job_started_data = JobStarted().json()
-    job_completed = JobCompleted(success=True, created_resources=[], processed_by="agent")
+    job_started_data = UpdateJobStatusRequest(data=JobStarted()).json()
+    job_completed = UpdateJobStatusRequest(
+        data=JobCompleted(success=True, created_resources=[], processed_by="agent")
+    )
     job_completed_data = job_completed.json()
 
     async def redeliver_message():
@@ -356,7 +359,7 @@ def test_gx_agent_sends_request_to_create_scheduled_job(
     """
     correlation_id = "4ae63677-4dd5-4fb0-b511-870e7a286e77"
     post_url = (
-        f"{gx_agent_config.gx_cloud_base_url}/organizations/"
+        f"{gx_agent_config.gx_cloud_base_url}/api/v1/organizations/"
         f"{gx_agent_config.gx_cloud_organization_id}/agent-jobs"
     )
 


### PR DESCRIPTION
This PR updates the core agent logic to use mercury FastAPI endpoints for receiving credentials, and updating actions as in progress and completed. It also updates the three run checkpoint actions to use oss V1 and FastAPI endpoints where applicable.