### PR TITLE
Logging - Event obj is not used directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GX cloud
+# GX Cloud
 
 [![PyPI](https://img.shields.io/pypi/v/great_expectations_cloud)](https://pypi.org/project/great-expectations_cloud/#history)
 [![Docker Pulls](https://img.shields.io/docker/pulls/greatexpectations/agent)](https://hub.docker.com/r/greatexpectations/agent)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GX Cloud
+# GX cloud
 
 [![PyPI](https://img.shields.io/pypi/v/great_expectations_cloud)](https://pypi.org/project/great-expectations_cloud/#history)
 [![Docker Pulls](https://img.shields.io/docker/pulls/greatexpectations/agent)](https://hub.docker.com/r/greatexpectations/agent)

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -481,11 +481,11 @@ class GXAgent:
         LOGGER.info(
             "Creating scheduled job and setting started",
             extra={
-                "correlation_id": event_context.correlation_id,
-                "event_type": event_context.event.type,
+                "correlation_id": str(event_context.correlation_id),
+                "event_type": str(event_context.event.type),
                 "organization_id": str(org_id),
-                "schedule_id": event_context.event.schedule_id,
-                "checkpoint_id": event_context.event.checkpoint_id,
+                "schedule_id": str(event_context.event.schedule_id),
+                "checkpoint_id": str(event_context.event.checkpoint_id),
             },
         )
 
@@ -498,11 +498,11 @@ class GXAgent:
             LOGGER.info(
                 "Created scheduled job and set started",
                 extra={
-                    "correlation_id": event_context.correlation_id,
-                    "event_type": event_context.event.type,
+                    "correlation_id": str(event_context.correlation_id),
+                    "event_type": str(event_context.event.type),
                     "organization_id": str(org_id),
-                    "schedule_id": event_context.event.schedule_id,
-                    "checkpoint_id": event_context.event.checkpoint_id,
+                    "schedule_id": str(event_context.event.schedule_id),
+                    "checkpoint_id": str(event_context.event.checkpoint_id),
                 },
             )
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -484,8 +484,6 @@ class GXAgent:
                 "correlation_id": str(event_context.correlation_id),
                 "event_type": str(event_context.event.type),
                 "organization_id": str(org_id),
-                "schedule_id": str(event_context.event.schedule_id),
-                "checkpoint_id": str(event_context.event.checkpoint_id),
             },
         )
 
@@ -501,8 +499,6 @@ class GXAgent:
                     "correlation_id": str(event_context.correlation_id),
                     "event_type": str(event_context.event.type),
                     "organization_id": str(org_id),
-                    "schedule_id": str(event_context.event.schedule_id),
-                    "checkpoint_id": str(event_context.event.checkpoint_id),
                 },
             )
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -476,11 +476,15 @@ class GXAgent:
         """
         data = {
             "correlation_id": event_context.correlation_id,
-            "event": event_context.event.dict(),
+            "event": event_context.event.type,
         }
         LOGGER.info(
             "Creating scheduled job and setting started",
-            extra={**data, "organization_id": str(org_id)},
+            extra={
+                "correlation_id": event_context.correlation_id,
+                "event_type": event_context.event.type,
+                "organization_id": str(org_id),
+            },
         )
 
         agent_sessions_url = (
@@ -491,7 +495,11 @@ class GXAgent:
             session.post(agent_sessions_url, data=payload.json())
             LOGGER.info(
                 "Created scheduled job and set started",
-                extra={**data, "organization_id": str(org_id)},
+                extra={
+                    "correlation_id": event_context.correlation_id,
+                    "event_type": event_context.event.type,
+                    "organization_id": str(org_id),
+                },
             )
 
     def get_header_name(self) -> type[HeaderName]:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -476,7 +476,7 @@ class GXAgent:
         """
         data = {
             "correlation_id": event_context.correlation_id,
-            "event": event_context.event.type,
+            "event": event_context.event.dict(),
         }
         LOGGER.info(
             "Creating scheduled job and setting started",
@@ -484,6 +484,8 @@ class GXAgent:
                 "correlation_id": event_context.correlation_id,
                 "event_type": event_context.event.type,
                 "organization_id": str(org_id),
+                "schedule_id": event_context.event.schedule_id,
+                "checkpoint_id": event_context.event.checkpoint_id,
             },
         )
 
@@ -499,6 +501,8 @@ class GXAgent:
                     "correlation_id": event_context.correlation_id,
                     "event_type": event_context.event.type,
                     "organization_id": str(org_id),
+                    "schedule_id": event_context.event.schedule_id,
+                    "checkpoint_id": event_context.event.checkpoint_id,
                 },
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241008.0"
+version = "20241010.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Update logging in Agent so that we are long passing `Event` object directly into logs. This will make debugging much easier. 