### PR TITLE
Refactor to ensure more consistent usage of correlation_id

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -282,7 +282,7 @@ class GXAgent:
             self._create_scheduled_job_and_set_started(event_context, org_id)
         else:
             self._update_status(
-                job_id=event_context.correlation_id, status=JobStarted(), org_id=org_id
+                correlation_id=event_context.correlation_id, status=JobStarted(), org_id=org_id
             )
         print(f"Starting job {event_context.event.type} ({event_context.correlation_id}) ")
         LOGGER.info(
@@ -366,7 +366,9 @@ class GXAgent:
                 },
             )
 
-        self._update_status(job_id=event_context.correlation_id, status=status, org_id=org_id)
+        self._update_status(
+            correlation_id=event_context.correlation_id, status=status, org_id=org_id
+        )
 
         # ack message and cleanup resources
         event_context.processed_successfully()
@@ -440,26 +442,35 @@ class GXAgent:
                 generate_config_validation_error_text(validation_err)
             ) from validation_err
 
-    def _update_status(self, job_id: str, status: JobStatus, org_id: UUID) -> None:
+    def _update_status(self, correlation_id: str, status: JobStatus, org_id: UUID) -> None:
         """Update GX Cloud on the status of a job.
 
         Args:
-            job_id: job identifier, also known as correlation_id
+            correlation_id: job identifier, also known as
             status: pydantic model encapsulating the current status
         """
         LOGGER.info(
             "Updating status",
-            extra={"job_id": job_id, "status": str(status), "organization_id": str(org_id)},
+            extra={
+                "correlation_id": correlation_id,
+                "status": str(status),
+                "organization_id": str(org_id),
+            },
         )
         agent_sessions_url = (
-            f"{self._config.gx_cloud_base_url}/organizations/{org_id}" + f"/agent-jobs/{job_id}"
+            f"{self._config.gx_cloud_base_url}/organizations/{org_id}"
+            + f"/agent-jobs/{correlation_id}"
         )
         with create_session(access_token=self.get_auth_key()) as session:
             data = status.json()
             session.patch(agent_sessions_url, data=data)
             LOGGER.info(
                 "Status updated",
-                extra={"job_id": job_id, "status": str(status), "organization_id": str(org_id)},
+                extra={
+                    "correlation_id": correlation_id,
+                    "status": str(status),
+                    "organization_id": str(org_id),
+                },
             )
 
     def _create_scheduled_job_and_set_started(
@@ -535,6 +546,7 @@ class GXAgent:
             extra={
                 "user_agent": header_name.USER_AGENT,
                 "agent_version": agent_version,
+                # why is there both the job_id and correlation_id here?
                 "job_id": header_name.AGENT_JOB_ID,
                 "correlation_id": correlation_id,
             },

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -546,8 +546,7 @@ class GXAgent:
             extra={
                 "user_agent": header_name.USER_AGENT,
                 "agent_version": agent_version,
-                # why is there both the job_id and correlation_id here?
-                "job_id": header_name.AGENT_JOB_ID,
+                "header_name": header_name.AGENT_JOB_ID,
                 "correlation_id": correlation_id,
             },
         )

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -446,8 +446,8 @@ class GXAgent:
         """Update GX Cloud on the status of a job.
 
         Args:
-            correlation_id: job identifier, also known as
-            status: pydantic model encapsulating the current status
+            correlation_id: job identifier
+            status: pydantic model encapsulating the current status.
         """
         LOGGER.info(
             "Updating status",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241010.0.dev0"
+version = "20241010.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -53,6 +53,7 @@ def build_get_draft_config_payload(
     }
 
 
+# try this
 @responses.activate
 def test_test_draft_datasource_config_success_non_sql_ds(
     mock_context, mocker: MockerFixture, set_required_env_vars: None
@@ -71,7 +72,7 @@ def test_test_draft_datasource_config_success_non_sql_ds(
     _get_table_names_spy = mocker.spy(action, "_get_table_names")
     _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
 
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -83,9 +84,9 @@ def test_test_draft_datasource_config_success_non_sql_ds(
         json=build_get_draft_config_payload(config=datasource_config, id=config_id),
     )
 
-    action_result = action.run(event=event, id=str(job_id))
+    action_result = action.run(event=event, id=str(correlation_id))
 
-    assert action_result.id == str(job_id)
+    assert action_result.id == str(correlation_id)
     assert action_result.type == event.type
     assert action_result.created_resources == []
 
@@ -140,7 +141,7 @@ def test_test_draft_datasource_config_success_sql_ds(
     _get_table_names_spy = mocker.spy(action, "_get_table_names")
     _update_table_names_list_spy = mocker.spy(action, "_update_table_names_list")
 
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -158,9 +159,9 @@ def test_test_draft_datasource_config_success_sql_ds(
         match=[responses.matchers.json_params_matcher({"table_names": table_names})],
     )
 
-    action_result = action.run(event=event, id=str(job_id))
+    action_result = action.run(event=event, id=str(correlation_id))
 
-    assert action_result.id == str(job_id)
+    assert action_result.id == str(correlation_id)
     assert action_result.type == event.type
     assert action_result.created_resources == []
 
@@ -210,7 +211,7 @@ def test_test_draft_datasource_config_sql_ds_raises_on_patch_failure(
         organization_id=org_id,
     )
 
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url: str = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -229,7 +230,7 @@ def test_test_draft_datasource_config_sql_ds_raises_on_patch_failure(
     )
 
     with pytest.raises(RuntimeError, match="Unable to update table_names for Draft Config with ID"):
-        action.run(event=event, id=str(job_id))
+        action.run(event=event, id=str(correlation_id))
 
 
 @responses.activate
@@ -249,7 +250,7 @@ def test_test_draft_datasource_config_failure(
         auth_key="",
         organization_id=org_id,
     )
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -265,7 +266,7 @@ def test_test_draft_datasource_config_failure(
     )
 
     with pytest.raises(GXCoreError):
-        action.run(event=event, id=str(job_id))
+        action.run(event=event, id=str(correlation_id))
 
 
 @responses.activate
@@ -282,7 +283,7 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
         auth_key="",
         organization_id=org_id,
     )
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -293,7 +294,7 @@ def test_test_draft_datasource_config_raises_for_non_fds(mock_context, set_requi
         json=build_get_draft_config_payload(config=datasource_config, id=config_id),
     )
     with pytest.raises(TypeError, match="fluent-style Data Source"):
-        action.run(event=event, id=str(job_id))
+        action.run(event=event, id=str(correlation_id))
 
 
 @pytest.mark.parametrize(
@@ -349,7 +350,7 @@ def test_test_draft_datasource_config_raises_for_unknown_type(
         auth_key="",
         organization_id=org_id,
     )
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -364,7 +365,7 @@ def test_test_draft_datasource_config_raises_for_unknown_type(
     )
 
     with pytest.raises(TypeError, match="unknown Data Source type"):
-        action.run(event=event, id=str(job_id))
+        action.run(event=event, id=str(correlation_id))
 
 
 @responses.activate
@@ -383,7 +384,7 @@ def test_test_draft_datasource_config_raises_for_cloud_backend_error(
         auth_key="",
         organization_id=org_id,
     )
-    job_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
+    correlation_id = UUID("87657a8e-f65e-4e64-b21f-e83a54738b75")
     event = DraftDatasourceConfigEvent(config_id=config_id, organization_id=uuid.uuid4())
     expected_url = (
         f"{env_vars.gx_cloud_base_url}/organizations/{env_vars.gx_cloud_organization_id}"
@@ -397,4 +398,4 @@ def test_test_draft_datasource_config_raises_for_cloud_backend_error(
     )
 
     with pytest.raises(RuntimeError, match="error while connecting to GX Cloud"):
-        action.run(event=event, id=str(job_id))
+        action.run(event=event, id=str(correlation_id))

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -53,7 +53,6 @@ def build_get_draft_config_payload(
     }
 
 
-# try this
 @responses.activate
 def test_test_draft_datasource_config_success_non_sql_ds(
     mock_context, mocker: MockerFixture, set_required_env_vars: None

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -523,7 +523,7 @@ def test_correlation_id_header(
     random_uuid: str,
 ):
     """Ensure agent-job-id/correlation-id header is set on GX Cloud api calls and updated for every new job."""
-    agent_job_ids: list[str] = [str(uuid.uuid4()) for _ in range(3)]
+    agent_correlation_ids: list[str] = [str(uuid.uuid4()) for _ in range(3)]
     datasource_config_id_1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
     datasource_config_id_2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
     checkpoint_id = uuid.UUID("00000000-0000-0000-0000-000000000003")
@@ -535,14 +535,14 @@ def test_correlation_id_header(
                     config_id=datasource_config_id_1,
                     organization_id=random_uuid,  # type: ignore[arg-type] # str coerced to UUID
                 ),
-                agent_job_ids[0],
+                agent_correlation_ids[0],
             ),
             (
                 DraftDatasourceConfigEvent(
                     config_id=datasource_config_id_2,
                     organization_id=random_uuid,  # type: ignore[arg-type] # str coerced to UUID
                 ),
-                agent_job_ids[1],
+                agent_correlation_ids[1],
             ),
             (
                 RunCheckpointEvent(
@@ -550,7 +550,7 @@ def test_correlation_id_header(
                     datasource_names_to_asset_names={},
                     organization_id=random_uuid,  # type: ignore[arg-type] # str coerced to UUID
                 ),
-                agent_job_ids[2],
+                agent_correlation_ids[2],
             ),
         ]
     )
@@ -567,21 +567,33 @@ def test_correlation_id_header(
             f"{base_url}/organizations/{org_id}/datasources/drafts/{datasource_config_id_1}",
             json={"data": {"attributes": {"draft_config": ds_config_factory("test-ds-1")}}},
             # match will fail if correlation-id header is not set
-            match=[responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: agent_job_ids[0]})],
+            match=[
+                responses.matchers.header_matcher(
+                    {HeaderName.AGENT_JOB_ID: agent_correlation_ids[0]}
+                )
+            ],
         )
         rsps.add(
             responses.GET,
             f"{base_url}/organizations/{org_id}/datasources/drafts/{datasource_config_id_2}",
             json={"data": {"attributes": {"draft_config": ds_config_factory("test-ds-2")}}},
             # match will fail if correlation-id header is not set
-            match=[responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: agent_job_ids[1]})],
+            match=[
+                responses.matchers.header_matcher(
+                    {HeaderName.AGENT_JOB_ID: agent_correlation_ids[1]}
+                )
+            ],
         )
         rsps.add(
             responses.GET,
             f"{base_url}organizations/{org_id}/checkpoints/{checkpoint_id}",
             json={"data": {}},
             # match will fail if correlation-id header is not set
-            match=[responses.matchers.header_matcher({HeaderName.AGENT_JOB_ID: agent_job_ids[2]})],
+            match=[
+                responses.matchers.header_matcher(
+                    {HeaderName.AGENT_JOB_ID: agent_correlation_ids[2]}
+                )
+            ],
         )
         agent = GXAgent()
         agent.run()


### PR DESCRIPTION
In the Agent we are using `correlation_id` and `job_id` interchangeably, which can cause confusion. This PR intends to use `correlation_id` in all locations, since it is what is used by mercury. 