### PR TITLE
Get view names along with tables

### DIFF
--- a/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
+++ b/great_expectations_cloud/agent/actions/draft_datasource_config_action.py
@@ -69,7 +69,7 @@ class DraftDatasourceConfigAction(AgentAction[DraftDatasourceConfigEvent]):
             created_resources=[],
         )
 
-    def _get_table_names(self, datasource: Datasource, include_views: bool = False) -> list[str]:
+    def _get_table_names(self, datasource: Datasource, *, include_views: bool) -> list[str]:
         inspector: Inspector = inspect(datasource.get_engine())
         names: list[str] = inspector.get_table_names()
         if include_views:

--- a/great_expectations_cloud/agent/actions/list_table_names.py
+++ b/great_expectations_cloud/agent/actions/list_table_names.py
@@ -36,9 +36,10 @@ class ListTableNamesAction(AgentAction[ListTableNamesEvent]):
 
         inspector: Inspector = inspect(datasource.get_engine())
         table_names: list[str] = inspector.get_table_names()
+        view_names: list[str] = inspector.get_view_names()
 
         self._add_or_update_table_names_list(
-            datasource_id=str(datasource.id), table_names=table_names
+            datasource_id=str(datasource.id), table_names=[*table_names, *view_names]
         )
 
         return ActionResult(

--- a/great_expectations_cloud/agent/actions/list_table_names.py
+++ b/great_expectations_cloud/agent/actions/list_table_names.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 
 class ListTableNamesAction(AgentAction[ListTableNamesEvent]):
+    """Return a list of the current table names (and views) for a given SQL based Datasource using the sqlalchemy inspector."""
+
     # TODO: New actions need to be created that are compatible with GX v1 and registered for v1.
     #  This action is registered for v0, see register_event_action()
 
@@ -36,10 +38,11 @@ class ListTableNamesAction(AgentAction[ListTableNamesEvent]):
 
         inspector: Inspector = inspect(datasource.get_engine())
         table_names: list[str] = inspector.get_table_names()
-        view_names: list[str] = inspector.get_view_names()
+        # consider views as well
+        table_names.extend(inspector.get_view_names())
 
         self._add_or_update_table_names_list(
-            datasource_id=str(datasource.id), table_names=[*table_names, *view_names]
+            datasource_id=str(datasource.id), table_names=table_names
         )
 
         return ActionResult(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241017.0.dev1"
+version = "20241021.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_draft_datasource_config.py
+++ b/tests/agent/actions/test_draft_datasource_config.py
@@ -170,7 +170,9 @@ def test_test_draft_datasource_config_success_sql_ds(
     assert action_result.created_resources == []
 
     # assert that the action properly calls helper methods to get table names and update the draft config
-    _get_table_names_spy.assert_called_with(datasource=datasource_cls(**datasource_config))
+    _get_table_names_spy.assert_called_with(
+        datasource=datasource_cls(**datasource_config), include_views=True
+    )
     _update_table_names_list_spy.assert_called_with(config_id=config_id, table_names=table_names)
 
 

--- a/tests/agent/actions/test_list_table_names_action.py
+++ b/tests/agent/actions/test_list_table_names_action.py
@@ -105,8 +105,10 @@ def test_run_list_table_names_action_returns_action_result(
     )
 
     table_names = ["table_1", "table_2", "table_3"]
+    view_names = ["view_1", "view_2"]
     inspector = mocker.Mock(spec=Inspector)
     inspector.get_table_names.return_value = table_names
+    inspector.get_view_names.return_value = view_names
 
     mock_inspect.return_value = inspector
 

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -72,6 +72,7 @@ def test_running_draft_datasource_config_action(
         "organization_users",
         "validations",
         "api_tokens",
+        "pg_stat_statements",  # view
     ]
     # add spies to the action methods
     _get_table_names_spy = mocker.spy(action, "_get_table_names")

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -69,6 +69,7 @@ def test_running_list_table_names_action(
         "organization_users",
         "user_asset_alerts",
         "validations",
+        "pg_stat_statements",
     ]
 
     # add spy to the action method


### PR DESCRIPTION
Return views along with table names.

Given that we no longer support `QueryAsset` types in GX-Cloud, users need to be able to import views along with tables when adding assets from the UI.


https://docs.sqlalchemy.org/en/20/core/reflection.html#sqlalchemy.engine.reflection.Inspector