### PR TITLE
Add headers to all stores

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -542,7 +542,7 @@ class GXAgent:
         from great_expectations.data_context.store.gx_cloud_store_backend import GXCloudStoreBackend
 
         # OSS doesn't use the same session for all requests, so we need to set the header for each store
-        stores = [store for store in data_context.stores.values()]
+        stores = list(data_context.stores.values())
         # some stores are treated differently
         stores.extend([data_context._datasource_store, data_context._data_asset_store])
         for store in stores:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -534,7 +534,7 @@ class GXAgent:
         return self.get_current_gx_agent_version()
 
     def _set_data_context_store_headers(
-        self, data_context: CloudDataContext, headers: dict
+        self, data_context: CloudDataContext, headers: Dict[str, str]
     ) -> None:
         """
         Sets headers on all stores in the data context.

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -531,7 +531,9 @@ class GXAgent:
     def _get_version(self) -> str:
         return self.get_current_gx_agent_version()
 
-    def _set_data_context_store_headers(self, data_context: CloudDataContext, headers: dict) -> None:
+    def _set_data_context_store_headers(
+        self, data_context: CloudDataContext, headers: dict
+    ) -> None:
         """
         Sets headers on all stores in the data context.
         """
@@ -546,9 +548,8 @@ class GXAgent:
             if isinstance(backend, GXCloudStoreBackend):
                 backend._session.headers.update(headers)
 
-
     def _set_http_session_headers(
-            self, data_context: CloudDataContext, correlation_id: str | None = None
+        self, data_context: CloudDataContext, correlation_id: str | None = None
     ) -> None:
         """
         Set the session headers for requests to GX Cloud.
@@ -577,9 +578,7 @@ class GXAgent:
             },
         )
 
-        core_headers = {
-            header_name.USER_AGENT: user_agent_header_value
-        }
+        core_headers = {header_name.USER_AGENT: user_agent_header_value}
         if correlation_id:
             core_headers.update({header_name.AGENT_JOB_ID: correlation_id})
         self._set_data_context_store_headers(data_context=data_context, headers=core_headers)

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -18,7 +18,6 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from great_expectations.data_context.data_context.context_factory import get_context
-from great_expectations.data_context.store import GXCloudStoreBackend
 from great_expectations.exceptions import GXCloudError
 from pika.adapters.utils.connection_workflow import (
     AMQPConnectorException,
@@ -536,6 +535,8 @@ class GXAgent:
         """
         Sets headers on all stores in the data context.
         """
+        from great_expectations.data_context.store.gx_cloud_store_backend import GXCloudStoreBackend
+
         # OSS doesn't use the same session for all requests, so we need to set the header for each store
         stores = [store for store in data_context.stores.values()]
         # some stores are treated differently

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -542,9 +542,7 @@ class GXAgent:
         stores.extend([data_context._datasource_store, data_context._data_asset_store])
         for store in stores:
             backend = store._store_backend
-            print(f"WTF: found store {backend.store_name}")
             if isinstance(backend, GXCloudStoreBackend):
-                print(f"WTF: setting header on backend {backend.store_name}")
                 backend._session.headers.update(headers)
 
 
@@ -569,9 +567,9 @@ class GXAgent:
         LOGGER.error(
             "Setting session headers for GX Cloud",
             extra={
-                "user_agent": header_name.USER_AGENT,
+                "user_agent_header_name": header_name.USER_AGENT,
                 "agent_version": agent_version,
-                "header_name": header_name.AGENT_JOB_ID,
+                "correlation_id_header_name": header_name.AGENT_JOB_ID,
                 "correlation_id": correlation_id,
             },
         )

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -534,7 +534,7 @@ class GXAgent:
         return self.get_current_gx_agent_version()
 
     def _set_data_context_store_headers(
-        self, data_context: CloudDataContext, headers: Dict[str, str]
+        self, data_context: CloudDataContext, headers: dict[HeaderName, str]
     ) -> None:
         """
         Sets headers on all stores in the data context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241023.0.dev0"
+version = "20241023.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
- adds agent headers to remaining stores (Data Source and Asset)
- overrides GX Core user agent for all stores

Requests coming from GX Agent should have GX Agent user agent, otherwise, they're not distinguishable from notebook or script usage

<img width="1392" alt="2024-10-24_09-36-19" src="https://github.com/user-attachments/assets/1fb10a49-56fa-423c-9b32-7478b47ebda7">