### PR TITLE
Properly disconnect from the GX Agent if a `GXAgentUnrecoverableError` is raised

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -164,6 +164,7 @@ class GXAgent:
 
     def run(self) -> None:
         """Open a connection to GX Cloud."""
+
         LOGGER.debug("Opening connection to GX Cloud.")
         self._listen()
         # we need a heavy-handed approach here to kill the main process to prevent a scenario where the agent is
@@ -192,7 +193,6 @@ class GXAgent:
             subscriber = Subscriber(client=client)
             LOGGER.info("The GX Agent is ready.")
             # Open a connection until encountering a shutdown event
-
             subscriber.consume(
                 queue=self._config.queue,
                 on_message=self._handle_event_as_thread_enter,
@@ -326,6 +326,7 @@ class GXAgent:
             event_context: event with related properties and actions.
         """
         # warning:  this method will not be executed in the main thread
+
         org_id = self.get_organization_id(event_context)
 
         # get results or errors from the thread

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -192,6 +192,7 @@ class GXAgent:
             subscriber = Subscriber(client=client)
             LOGGER.info("The GX Agent is ready.")
             # Open a connection until encountering a shutdown event
+
             subscriber.consume(
                 queue=self._config.queue,
                 on_message=self._handle_event_as_thread_enter,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -367,8 +367,8 @@ class GXAgent:
                 )
         else:
             status = build_failed_job_completed_status(error)
-            LOGGER.error(traceback.format_exc())
-            LOGGER.error(
+            LOGGER.info(traceback.format_exc())
+            LOGGER.info(
                 "Job completed with error",
                 extra={
                     "event_type": event_context.event.type,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -136,7 +136,7 @@ class GXAgent:
         agent_version: str = self.get_current_gx_agent_version()
         great_expectations_version: str = self._get_current_great_expectations_version()
         LOGGER.info(
-            "Initializing GX Agent",
+            "Initializing GX Agent.",
             extra={
                 "agent_version": agent_version,
                 "great_expectations_version": great_expectations_version,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -136,7 +136,7 @@ class GXAgent:
         agent_version: str = self.get_current_gx_agent_version()
         great_expectations_version: str = self._get_current_great_expectations_version()
         LOGGER.info(
-            "Initializing GX Agent.",
+            "Initializing GX Agent",
             extra={
                 "agent_version": agent_version,
                 "great_expectations_version": great_expectations_version,

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -238,7 +238,7 @@ class AsyncRabbitMQClient:
         # self._reconnect()
 
     def _on_connection_closed(
-        self, connection: AsyncioConnection, _unused_reason: pika.Exception
+        self, _unused_connection: AsyncioConnection, _unused_reason: pika.Exception
     ) -> None:
         """Callback invoked after the broker closes the connection"""
         # TODO: Fix reconnect logic and add a call here to reconnect if appropriate
@@ -247,7 +247,8 @@ class AsyncRabbitMQClient:
         self._is_unrecoverable = True
         # we need to call stop to break out of the run_forever call,
         # see: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_forever
-        self._connection.ioloop.stop()
+        if self._connection is not None:
+            self._connection.ioloop.stop()
 
     def _close_connection(self, reason: pika.Exception) -> None:
         """Close the connection to the broker."""

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -226,14 +226,13 @@ class AsyncRabbitMQClient:
         self, _unused_connection: AsyncioConnection, reason: pika.Exception
     ) -> None:
         """Callback invoked when there is an error while opening connection."""
-        self._reconnect()
         LOGGER.error(
             "Connection open failed",
             extra={
-                "reply_code": reason.reply_code,
-                "reply_text": reason.reply_text,
+                "reason": reason,
             },
         )
+        self._reconnect()
 
     def _on_connection_closed(
         self, connection: AsyncioConnection, _unused_reason: pika.Exception
@@ -245,6 +244,12 @@ class AsyncRabbitMQClient:
         if self._closing:
             connection.ioloop.stop()
         else:
+            LOGGER.warning(
+                "Connection closed, reconnect necessary",
+                extra={
+                    "reason": reason,
+                },
+            )
             self._reconnect()
 
     def _close_connection(self, reason: pika.Exception) -> None:

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -91,7 +91,8 @@ class AsyncRabbitMQClient:
                 self._connection.ioloop.run_forever()
             else:
                 self._connection.ioloop.stop()
-            LOGGER.debug("The connection to RabbitMQ has been shut down.")
+        LOGGER.debug("The connection to RabbitMQ has been shut down.")
+
 
     def reset(self) -> None:
         """Reset client to allow a restart."""

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -93,7 +93,6 @@ class AsyncRabbitMQClient:
                 self._connection.ioloop.stop()
         LOGGER.debug("The connection to RabbitMQ has been shut down.")
 
-
     def reset(self) -> None:
         """Reset client to allow a restart."""
         LOGGER.debug("Resetting client")

--- a/great_expectations_cloud/agent/message_service/subscriber.py
+++ b/great_expectations_cloud/agent/message_service/subscriber.py
@@ -103,10 +103,11 @@ class Subscriber:
             except GXAgentUnrecoverableConnectionError:
                 self.client.stop()
                 raise
-            if self.client.should_reconnect:
-                self.client.reset()
-            else:
-                break  # exit
+            finally:
+                if self.client.should_reconnect:
+                    # TODO: Right now, this block will not actually reconnect the client. The client code needs to be
+                    #  finished so that there is actually a way to reconnect
+                    self.client.reset()
 
     def _on_message_handler(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241031.0.dev0"
+version = "20241101.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
This is for [ZELDA-1063](https://greatexpectations.atlassian.net/browse/ZELDA-1063). 

This PR does the following: 
- Corrects the logic in the GX Agent so that we successfully disconnect if a `GXAgentUnrecoverableError` is raised
- Removes broken attempts to reconnect the client. We decided that in the interest of time, it is better to kill the connection and let Kubernetes spin a new one up. Future work can address reconnection from the client. 
- Adds structured logging to the agent and RabbitMQ client code

See [this](https://greatexpectations.atlassian.net/wiki/spaces/SUP/pages/1391034381/GX+Runner+-+Long+Job+Resilience) writeup for more context about the issue. 

**Testing**
I was able to reproduce the RabbitMQ Delivery Acknowledgement Timeout locally by adding a `sleep` call to the `run_checkpoint` job. 

TODO: Verify in Linux that the command we are using to kill the agent is kosher. 

[ZELDA-1063]: https://greatexpectations.atlassian.net/browse/ZELDA-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ