### PR TITLE
Configure progress bars in the GX Agent 

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -95,7 +95,7 @@ class GXAgentConfig(AgentBaseExtraForbid):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
-    enable_progress_bars: bool = False
+    enable_progress_bars: bool = True
 
 
 def orjson_dumps(v: Any, *, default: Callable[[Any], Any] | None) -> str:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -19,6 +19,7 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from great_expectations.data_context.data_context.context_factory import get_context
+from great_expectations.data_context.types.base import ProgressBarsConfig
 from great_expectations.exceptions import GXCloudError
 from pika.adapters.utils.connection_workflow import (
     AMQPConnectorException,
@@ -94,6 +95,7 @@ class GXAgentConfig(AgentBaseExtraForbid):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
+    enable_progress_bars: bool = False
 
 
 def orjson_dumps(v: Any, *, default: Callable[[Any], Any] | None) -> str:
@@ -148,6 +150,7 @@ class GXAgent:
             # suppress warnings about GX version
             warnings.filterwarnings("ignore", message="You are using great_expectations version")
             self._context: CloudDataContext = get_context(cloud_mode=True)
+            self._configure_progress_bars()
         LOGGER.debug("DataContext is ready.")
 
         self._set_http_session_headers(data_context=self._context)
@@ -458,6 +461,24 @@ class GXAgent:
             raise GXAgentConfigError(
                 generate_config_validation_error_text(validation_err)
             ) from validation_err
+
+    def _configure_progress_bars(self) -> None:
+        progress_bars_enabled = self._config.enable_progress_bars
+
+        try:
+            self._context.variables.progress_bars = ProgressBarsConfig(
+                globally=progress_bars_enabled,
+                metric_calculations=progress_bars_enabled,
+            )
+            self._context.variables.save()
+        except Exception:
+            # Progress bars are not critical, so log and continue
+            # This is a known issue with FastAPI mercury V1 API for data-context-variables
+            LOGGER.warning(
+                "Failed to {set} progress bars".format(
+                    set="enable" if progress_bars_enabled else "disable"
+                )
+            )
 
     def _update_status(self, correlation_id: str, status: JobStatus, org_id: UUID) -> None:
         """Update GX Cloud on the status of a job.

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -150,7 +150,7 @@ class GXAgent:
             # suppress warnings about GX version
             warnings.filterwarnings("ignore", message="You are using great_expectations version")
             self._context: CloudDataContext = get_context(cloud_mode=True)
-            self._configure_progress_bars()
+            self._configure_progress_bars(data_context=self._context)
         LOGGER.debug("DataContext is ready.")
 
         self._set_http_session_headers(data_context=self._context)
@@ -463,15 +463,15 @@ class GXAgent:
                 generate_config_validation_error_text(validation_err)
             ) from validation_err
 
-    def _configure_progress_bars(self) -> None:
+    def _configure_progress_bars(self, data_context: CloudDataContext) -> None:
         progress_bars_enabled = self._config.enable_progress_bars
 
         try:
-            self._context.variables.progress_bars = ProgressBarsConfig(
+            data_context.variables.progress_bars = ProgressBarsConfig(
                 globally=progress_bars_enabled,
                 metric_calculations=progress_bars_enabled,
             )
-            self._context.variables.save()
+            data_context.variables.save()
         except Exception:
             # Progress bars are not critical, so log and continue
             # This is a known issue with FastAPI mercury V1 API for data-context-variables

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -456,6 +456,7 @@ class GXAgent:
                 gx_cloud_base_url=env_vars.gx_cloud_base_url,
                 gx_cloud_organization_id=env_vars.gx_cloud_organization_id,
                 gx_cloud_access_token=env_vars.gx_cloud_access_token,
+                enable_progress_bars=env_vars.enable_progress_bars,
             )
         except pydantic_v1.ValidationError as validation_err:
             raise GXAgentConfigError(

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -9,7 +9,7 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
-    enable_progress_bars: bool = False
+    enable_progress_bars: bool = True
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -11,7 +11,7 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_access_token: str
     enable_progress_bars: bool = False
 
-    def __init__(self, **overrides: str | bool | AnyUrl) -> None:
+    def __init__(self, **overrides: str | AnyUrl) -> None:
         """
         Custom __init__ to prevent type error when relying on environment variables.
 

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -9,6 +9,7 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_base_url: AnyUrl = CLOUD_DEFAULT_BASE_URL
     gx_cloud_organization_id: str
     gx_cloud_access_token: str
+    enable_progress_bars: bool = False
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -11,7 +11,7 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_access_token: str
     enable_progress_bars: bool = False
 
-    def __init__(self, **overrides: str | AnyUrl) -> None:
+    def __init__(self, **overrides: str | bool | AnyUrl) -> None:
         """
         Custom __init__ to prevent type error when relying on environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241120.0"
+version = "20241120.1.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241120.0.dev0"
+version = "20241120.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -60,7 +60,13 @@ def set_required_env_vars(monkeypatch, random_uuid, random_string, local_mercury
 
 @pytest.fixture
 def gx_agent_config(
-    set_required_env_vars, queue, connection_string, random_uuid, random_string, local_mercury
+    set_required_env_vars,
+    queue,
+    connection_string,
+    random_uuid,
+    random_string,
+    local_mercury,
+    enable_progress_bars,
 ) -> GXAgentConfig:
     config = GXAgentConfig(
         queue=queue,
@@ -68,6 +74,7 @@ def gx_agent_config(
         gx_cloud_access_token=random_string,
         gx_cloud_organization_id=random_uuid,
         gx_cloud_base_url=local_mercury,
+        enable_progress_bars=enable_progress_bars,
     )
     return config
 
@@ -192,6 +199,16 @@ def requests_post(mocker, queue, connection_string):
 def test_gx_agent_gets_env_vars_on_init(get_context, gx_agent_config, requests_post):
     agent = GXAgent()
     assert agent._config == gx_agent_config
+
+
+@pytest.mark.parametrize("enable_progress_bars", [True, False])
+def test_gx_agent_configures_progress_bars_on_init(
+    monkeypatch, enable_progress_bars, get_context, gx_agent_config, requests_post
+):
+    monkeypatch.setenv("ENABLE_PROGRESS_BARS", str(enable_progress_bars))
+    agent = GXAgent()
+    assert agent._context.variables.progress_bars.globally == enable_progress_bars
+    assert agent._context.variables.progress_bars.metric_calculations == enable_progress_bars
 
 
 def test_gx_agent_invalid_token(monkeypatch, set_required_env_vars: None):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -66,7 +66,6 @@ def gx_agent_config(
     random_uuid,
     random_string,
     local_mercury,
-    enable_progress_bars,
 ) -> GXAgentConfig:
     config = GXAgentConfig(
         queue=queue,
@@ -74,7 +73,6 @@ def gx_agent_config(
         gx_cloud_access_token=random_string,
         gx_cloud_organization_id=random_uuid,
         gx_cloud_base_url=local_mercury,
-        enable_progress_bars=enable_progress_bars,
     )
     return config
 


### PR DESCRIPTION
Move the configuration of the progress bar from the GX Runner to the Agent, where it will be controlled by an environment variable. This PR should be merged prior to removing config from the Runner. 

PR to remove progress bar config from the Runner is [here](https://github.com/greatexpectationslabs/gx-runner/pull/242).

Also see ticket [here](https://greatexpectations.atlassian.net/jira/software/c/projects/ZELDA/boards/85?selectedIssue=ZELDA-1124).

Added tests to check that we configure progress bars correctly when the agent is initialized, and also verified that this works locally when the `ENABLE_PROGRESS_BARS` environment variable is set to True, False, or when it is not set (defaults to True)