### PR TITLE
Schema Change Detection - Update Model, which does not need Suite ID

### DIFF
--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -109,7 +109,6 @@ class GenerateSchemaChangeExpectationsEvent(EventBase):
     )
     datasource_name: str
     data_assets: Sequence[str]
-    expectation_suite_id: UUID
     create_expectations: bool = False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241121.0.dev0"
+version = "20241121.0.dev1"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241120.0"
+version = "20241121.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -46,7 +46,6 @@ def test_generate_schema_change_expectations_action_smoke_test(
             organization_id=uuid.uuid4(),
             datasource_name="test-datasource",
             data_assets=["test-data-asset1", "test-data-asset2"],
-            expectation_suite_id=uuid.uuid4(),
             create_expectations=True,
         ),
         id="test-id",


### PR DESCRIPTION
`GenerateSchemaChangeExpectationsEvent` does not need `ExpectationSuiteId` because it is generated per-asset when the Action is run. 