### PR TITLE
Use nginx for routing mercury API calls 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,8 @@ jobs:
           docker compose run db-seeder
           docker compose run mq-wait
           docker compose up mercury-service-api -d
+          docker compose up mercury-service-api-v1 -d
+          docker compose up nginx -d
 
       - name: Show logs for debugging
         if: failure()

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -99,6 +99,10 @@ jobs:
           docker compose run mq-wait
           echo "STARTING mercury-service-api"
           docker compose up mercury-service-api -d
+          echo "STARTING mercury-service-api-v1"
+          docker compose up mercury-service-api-v1 -d
+          echo "STARTING nginx"
+          docker compose up nginx -d
           echo "STARTING gx-agent"
           docker compose up gx-agent -d
           echo "RUNNING TESTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,15 +42,52 @@ services:
     depends_on:
       - mq
 
-  mercury-service-api:
+  nginx:
+    image: nginx:latest
+    container_name: nginx_container
+    ports:
+      # Nginx runs on port 80
+      - 5000:80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - mercury-service-api
+      - mercury-service-api-v1
+
+  mercury-service-api-v1:
     platform: linux/amd64
     image: 258143015559.dkr.ecr.us-east-1.amazonaws.com/mercury/api:v1api-latest
     restart: always
     volumes:
       - ./services/ge_cloud/:/code
-    ports:
-      # V1 runs on external port 7000
-      - 5000:7000
+    environment:
+      LOGGING_LEVEL: ${LOGGING_LEVEL}
+      ENVIRONMENT: ${ENVIRONMENT}
+      MERCURY_DIALECT: postgresql
+      MERCURY_USER: gx_mercury_user
+      MERCURY_PASSWORD: postgres
+      MERCURY_HOST: db
+      MERCURY_DATABASE: mercury
+      GE_USAGE_STATISTICS_URL: ${GE_USAGE_STATISTICS_URL}
+      AMQP_CONNECTION_STRING: amqp://gx_prod:password@mq:5672
+      AMQP_REST_PORT: 15672
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
+      AUTH0_API_AUDIENCE: ${AUTH0_API_AUDIENCE}
+      AUTH0_MERCURY_API_CLIENT_ID: ${AUTH0_MERCURY_API_CLIENT_ID}
+      AUTH0_MERCURY_API_CLIENT_SECRET: ${AUTH0_MERCURY_API_CLIENT_SECRET}
+      SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET}
+      SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN}
+      SLACK_REDIRECT_URI: ${SLACK_REDIRECT_URI}
+      SLACK_CLIENT_ID: ${SLACK_CLIENT_ID}
+      SENDGRID_API_KEY: ${SENDGRID_API_KEY}
+      LD_SDK_KEY: ${LD_SDK_KEY}
+
+  mercury-service-api:
+    platform: linux/amd64
+    image: 258143015559.dkr.ecr.us-east-1.amazonaws.com/mercury/api:latest
+    restart: always
+    volumes:
+      - ./services/ge_cloud/:/code
     environment:
       LOGGING_LEVEL: ${LOGGING_LEVEL}
       ENVIRONMENT: ${ENVIRONMENT}
@@ -122,3 +159,4 @@ services:
       GX_CLOUD_BASE_URL: ${GX_CLOUD_BASE_URL}
     depends_on:
       - mercury-service-api
+      - mercury-service-api-v1

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+events{}
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://mercury-service-api:5000;
+        }
+        location /api/v1 {
+            proxy_pass http://mercury-service-api-v1:7000/api/v1;
+        }
+    }
+}

--- a/tasks.py
+++ b/tasks.py
@@ -379,5 +379,7 @@ def start_supporting_services(ctx: Context) -> None:
         "docker compose run db-seeder",
         "docker compose run mq-wait",
         "docker compose up mercury-service-api -d",
+        "docker compose up mercury-service-api-v1 -d",
+        "docker compose up nginx -d",
     ]:
         ctx.run(cmd, echo=True, pty=True)


### PR DESCRIPTION
Add nginx to route mercury API calls to the correct port depending on whether or not we are hitting the v0 or v1 endpoint. This mirrors the pattern used in the `gx-runner` repo and will allow us to [re-enable integration tests](https://github.com/great-expectations/cloud/pull/549) for the Agent. 