### PR TITLE
Capture exception via logs

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -20,7 +20,6 @@ from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from great_expectations.data_context.data_context.context_factory import get_context
 from great_expectations.data_context.types.base import ProgressBarsConfig
-from great_expectations.exceptions import GXCloudError
 from pika.adapters.utils.connection_workflow import (
     AMQPConnectorException,
 )
@@ -511,7 +510,7 @@ class GXAgent:
                     "organization_id": str(org_id),
                 },
             )
-            GXAgent._raise_gx_cloud_err_on_http_error(
+            GXAgent._log_http_error(
                 response, message="Status Update action had an error while connecting to GX Cloud."
             )
 
@@ -567,7 +566,7 @@ class GXAgent:
                     "schedule_id": str(event_context.event.schedule_id),
                 },
             )
-            GXAgent._raise_gx_cloud_err_on_http_error(
+            GXAgent._log_http_error(
                 response,
                 message="Create schedule job action had an error while connecting to GX Cloud.",
             )
@@ -655,14 +654,12 @@ class GXAgent:
         http._update_headers = _update_headers_agent_patch
 
     @staticmethod
-    def _raise_gx_cloud_err_on_http_error(response: requests.Response, message: str) -> None:
+    def _log_http_error(response: requests.Response, message: str) -> None:
         """
-        Raise GXCloudError if the response is not successful.
+        Log the http error if the response is not successful.
         """
         try:
             response.raise_for_status()
-        except requests.HTTPError as http_err:
-            raise GXCloudError(
-                message=message,
-                response=response,
-            ) from http_err
+        except requests.HTTPError:
+            # LOGGER.error(traceback.format_exc(), extra={"response": response, "error_message": message})
+            LOGGER.exception(message, extra={"response": response})

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -661,5 +661,4 @@ class GXAgent:
         try:
             response.raise_for_status()
         except requests.HTTPError:
-            # LOGGER.error(traceback.format_exc(), extra={"response": response, "error_message": message})
             LOGGER.exception(message, extra={"response": response})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241120.1.dev0"
+version = "20241121.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import random
 import string
 import uuid
@@ -634,7 +633,6 @@ def test_correlation_id_header(
 
 
 def test_log_err_on_http_error_error_response(caplog):
-    caplog.set_level(logging.ERROR)
     test_response = requests.Response()
     # 404 - Not Found
     test_response.status_code = 404

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import random
 import string
 import uuid
@@ -632,17 +633,19 @@ def test_correlation_id_header(
         agent.run()
 
 
-def test_raise_gx_cloud_err_on_http_error_error_response():
+def test_log_err_on_http_error_error_response(caplog):
+    caplog.set_level(logging.ERROR)
     test_response = requests.Response()
     # 404 - Not Found
     test_response.status_code = 404
-    with pytest.raises(gx_exception.GXCloudError):
-        GXAgent._raise_gx_cloud_err_on_http_error(test_response, "Test error message")
+    error_msg = "Test error message"
+    GXAgent._log_http_error(test_response, error_msg)
+    assert caplog.records[0].message == error_msg
 
 
-def test_raise_gx_cloud_err_on_http_error_success_response():
+def test_log_err_on_http_error_success_response(caplog):
     test_response = requests.Response()
     # 200 - OK
     test_response.status_code = 200
-    # no Exception raised
-    GXAgent._raise_gx_cloud_err_on_http_error(test_response, "Test error message")
+    # no Exception logged
+    assert caplog.records == []


### PR DESCRIPTION
Previously, the exception raised when either updating the job status or creating a job in the backend for scheduled jobs would show as a multi-line exception in datadog. Since these errors are raised during the processing of an action, they should be logged rather than raised. Other errors raised during the processing of an action are already successfully caught and logged.

This PR uses our existing json logging framework to log the error as json.

Example new log:
```
{"args": "()", "levelname": "'ERROR'", "filename": "'agent.py'", "module": "'agent'", "exc_info": "None", "stack_info": "None", "funcName": "'_log_http_error'", "created": "1732221296.059027", "relativeCreated": "11169.095039367676", "response": "<Response [204]>", "error_message": "'Status Update action had an error while connecting to GX Cloud.'", "event": "'Traceback (most recent call last):\\n  File \"/path_to_code/cloud/great_expectations_cloud/agent/agent.py\", line 669, in _log_http_error\\n    raise requests.HTTPError\\nrequests.exceptions.HTTPError\\n'", "level": "'ERROR'", "logger": "'great_expectations_cloud.agent.agent'", "timestamp": "'2024-11-21T20:34:56.059027+00:00'"}
```

The previous log stretched across many datadog events:
![image](https://github.com/user-attachments/assets/5c860c8c-f486-4721-9db7-6a8c2b07fab0)
