### PR TITLE
GenerateSchemaChangeExpectationAction - Enable Integration Test

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -64,7 +64,7 @@ class GenerateSchemaChangeExpectationsAction(AgentAction[GenerateSchemaChangeExp
                 data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
                 metric_run, metric_run_id = self._get_metrics(data_asset)
                 # this logic will change with ZELDA-1154 and we will be pulling this in from a mapping
-                expectation_suite_name = f"{data_asset.name} - Expectation Suite"
+                expectation_suite_name = f"{data_asset.name} Suite"
                 expectation = self._add_schema_change_expectation(
                     metric_run, expectation_suite_name
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241122.0.dev0"
+version = "20241123.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -75,7 +75,7 @@ def test_running_schema_change_expectation_action(
     generate_schema_change_expectations_event = GenerateSchemaChangeExpectationsEvent(
         type="generate_schema_change_expectations_request.received",
         datasource_name="local_mercury_db",
-        data_assets=["local-mercury-db-organizations-table"],
+        data_assets=["local-mercury-db-checkpoints-table"],
         organization_id=uuid.UUID(org_id_env_var_local),
     )
 

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -63,7 +63,6 @@ def local_mercury_db_organizations_table_asset(
     yield data_asset
 
 
-@pytest.mark.skip(reason="This test will be updated in a follow-up PR")
 def test_running_schema_change_expectation_action(
     context: CloudDataContext,
     user_api_token_headers_org_admin_sc_org,

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -75,7 +75,7 @@ def test_running_schema_change_expectation_action(
     generate_schema_change_expectations_event = GenerateSchemaChangeExpectationsEvent(
         type="generate_schema_change_expectations_request.received",
         datasource_name="local_mercury_db",
-        data_assets=["checkpoints"],
+        data_assets=["local-mercury-db-organizations-table"],
         organization_id=uuid.UUID(org_id_env_var_local),
     )
 

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -90,6 +90,9 @@ def test_running_schema_change_expectation_action(
     action_result = action.run(event=generate_schema_change_expectations_event, id=event_id)
 
     # Assert
-    # Check that the action was successful e.g. that we can create metrics_list_request action
     assert action_result.type == generate_schema_change_expectations_event.type
     assert action_result.id == event_id
+    # expected resources were created
+    assert len(action_result.created_resources) == 2
+    assert action_result.created_resources[0].type == "MetricRun"
+    assert action_result.created_resources[1].type == "Expectation"


### PR DESCRIPTION
* Enable Integration test
* Added seed-data as part of the integration test that is subsequently cleaned up. 