### PR TITLE
Improve error reporting for partial failed assets

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -54,14 +54,14 @@ class PartialSchemaChangeExpectationError(GXAgentError):
             )
             num_errors_not_displayed = len(self.asset_to_error_map) - self.MAX_ERRORS_TO_DISPLAY
 
-            num_error_display_msg = f"Only displaying the first {self.MAX_ERRORS_TO_DISPLAY} errors. There {'is' if num_errors_not_displayed == 1 else 'are'} {num_errors_not_displayed} additional error{'' if num_errors_not_displayed == 1 else 's'}."
+            num_error_display_msg = f"Only displaying the first {self.MAX_ERRORS_TO_DISPLAY} errors. There {'is' if num_errors_not_displayed == 1 else 'are'} {num_errors_not_displayed} additional error{'' if num_errors_not_displayed == 1 else 's'}. "
         else:
             errors_to_display = self.asset_to_error_map
             num_error_display_msg = ""
-        errors = "\n".join(
+        errors = " ----- \n".join(
             f"Asset: {asset_name} Error: {error}" for asset_name, error in errors_to_display.items()
         )
-        return f"{self.message}\n{num_error_display_msg}Errors:\n{errors}"
+        return f"{self.message}\n{num_error_display_msg}Errors:\n----- {errors}"
 
     def __str__(self):
         return self._build_error_message()

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -50,9 +50,8 @@ class PartialSchemaChangeExpectationError(GXAgentError):
             errors_to_display = dict(
                 list(self.asset_to_error_map.items())[: self.max_errors_to_display]
             )
-            num_error_display_msg = (
-                f"Only displaying the first {self.max_errors_to_display} errors. "
-            )
+            errors_not_displayed = len(self.asset_to_error_map) - self.max_errors_to_display
+            num_error_display_msg = f"Only displaying the first {self.max_errors_to_display} errors. There {'is' if errors_not_displayed == 1 else 'are'} {errors_not_displayed} additional error{'' if errors_not_displayed == 1 else 's'}."
         else:
             errors_to_display = self.asset_to_error_map
             num_error_display_msg = ""

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from itertools import islice
 from typing import TYPE_CHECKING, Final
 from uuid import UUID
 
@@ -47,11 +48,13 @@ class PartialSchemaChangeExpectationError(GXAgentError):
 
     def _build_error_message(self) -> str:
         if len(self.asset_to_error_map) > self.MAX_ERRORS_TO_DISPLAY:
+            # Get the first MAX_ERRORS_TO_DISPLAY errors to display:
             errors_to_display = dict(
-                list(self.asset_to_error_map.items())[: self.MAX_ERRORS_TO_DISPLAY]
+                islice(self.asset_to_error_map.items(), self.MAX_ERRORS_TO_DISPLAY)
             )
-            errors_not_displayed = len(self.asset_to_error_map) - self.MAX_ERRORS_TO_DISPLAY
-            num_error_display_msg = f"Only displaying the first {self.MAX_ERRORS_TO_DISPLAY} errors. There {'is' if errors_not_displayed == 1 else 'are'} {errors_not_displayed} additional error{'' if errors_not_displayed == 1 else 's'}."
+            num_errors_not_displayed = len(self.asset_to_error_map) - self.MAX_ERRORS_TO_DISPLAY
+
+            num_error_display_msg = f"Only displaying the first {self.MAX_ERRORS_TO_DISPLAY} errors. There {'is' if num_errors_not_displayed == 1 else 'are'} {num_errors_not_displayed} additional error{'' if num_errors_not_displayed == 1 else 's'}."
         else:
             errors_to_display = self.asset_to_error_map
             num_error_display_msg = ""

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -43,9 +43,9 @@ class PartialSchemaChangeExpectationError(GXAgentError):
         self.asset_to_error_map = asset_to_error_map
         num_assets_with_errors = len(self.asset_to_error_map)
         self.message = f"Failed to generate schema change expectations for {num_assets_with_errors} of the {assets_attempted} assets."
-        super().__init__(self.message)
+        super().__init__(self._build_error_message())
 
-    def __str__(self):
+    def _build_error_message(self) -> str:
         if len(self.asset_to_error_map) > self.max_errors_to_display:
             errors_to_display = dict(
                 list(self.asset_to_error_map.items())[: self.max_errors_to_display]
@@ -59,7 +59,10 @@ class PartialSchemaChangeExpectationError(GXAgentError):
         errors = "\n".join(
             f"Asset: {asset_name} Error: {error}" for asset_name, error in errors_to_display.items()
         )
-        return f"{self.message}\n{num_error_display_msg}Errors:{errors}"
+        return f"{self.message}\n{num_error_display_msg}Errors:\n{errors}"
+
+    def __str__(self):
+        return self._build_error_message()
 
 
 class GenerateSchemaChangeExpectationsAction(AgentAction[GenerateSchemaChangeExpectationsEvent]):

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -39,19 +39,19 @@ LOGGER.setLevel(logging.DEBUG)
 
 class PartialSchemaChangeExpectationError(GXAgentError):
     def __init__(self, asset_to_error_map: dict[str, Exception], assets_attempted: int):
-        self.max_errors_to_display = 5
+        self.MAX_ERRORS_TO_DISPLAY = 5
         self.asset_to_error_map = asset_to_error_map
         num_assets_with_errors = len(self.asset_to_error_map)
         self.message = f"Failed to generate schema change expectations for {num_assets_with_errors} of the {assets_attempted} assets."
         super().__init__(self._build_error_message())
 
     def _build_error_message(self) -> str:
-        if len(self.asset_to_error_map) > self.max_errors_to_display:
+        if len(self.asset_to_error_map) > self.MAX_ERRORS_TO_DISPLAY:
             errors_to_display = dict(
-                list(self.asset_to_error_map.items())[: self.max_errors_to_display]
+                list(self.asset_to_error_map.items())[: self.MAX_ERRORS_TO_DISPLAY]
             )
-            errors_not_displayed = len(self.asset_to_error_map) - self.max_errors_to_display
-            num_error_display_msg = f"Only displaying the first {self.max_errors_to_display} errors. There {'is' if errors_not_displayed == 1 else 'are'} {errors_not_displayed} additional error{'' if errors_not_displayed == 1 else 's'}."
+            errors_not_displayed = len(self.asset_to_error_map) - self.MAX_ERRORS_TO_DISPLAY
+            num_error_display_msg = f"Only displaying the first {self.MAX_ERRORS_TO_DISPLAY} errors. There {'is' if errors_not_displayed == 1 else 'are'} {errors_not_displayed} additional error{'' if errors_not_displayed == 1 else 's'}."
         else:
             errors_to_display = self.asset_to_error_map
             num_error_display_msg = ""

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -63,9 +63,6 @@ class PartialSchemaChangeExpectationError(GXAgentError):
         )
         return f"{self.message}\n{num_error_display_msg}Errors:\n----- {errors}"
 
-    def __str__(self):
-        return self._build_error_message()
-
 
 class GenerateSchemaChangeExpectationsAction(AgentAction[GenerateSchemaChangeExpectationsEvent]):
     def __init__(  # noqa: PLR0913  # Refactor opportunity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241122.0.dev0"
+version = "20241126.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -399,13 +399,14 @@ def test_action_failure_in_add_schema_change_expectation(
 
 
 @pytest.mark.parametrize(
-    "succeeding_data_asset_names, failing_data_asset_names, failing_data_asset_error_messages, expected_error_message",
+    "succeeding_data_asset_names, failing_data_asset_names, failing_data_asset_error_messages, expected_error_message, expected_truncation_message",
     [
         pytest.param(
             ["test-data-asset1"],
             ["retrieve-fail-asset-1"],
             ["Failed to retrieve asset: retrieve-fail-asset-1"],
             "Failed to generate schema change expectations for 1 of the 2 assets.",
+            "",
             id="Single asset passing, single asset failing",
         ),
         pytest.param(
@@ -413,6 +414,7 @@ def test_action_failure_in_add_schema_change_expectation(
             ["retrieve-fail-asset-1"],
             ["Failed to retrieve asset: retrieve-fail-asset-1"],
             "Failed to generate schema change expectations for 1 of the 3 assets.",
+            "",
             id="Multiple assets passing, single asset failing",
         ),
         pytest.param(
@@ -430,7 +432,59 @@ def test_action_failure_in_add_schema_change_expectation(
                 "One or more metrics failed to compute.",
             ],
             "Failed to generate schema change expectations for 4 of the 6 assets.",
+            "",
             id="Multiple assets passing, multiple assets failing",
+        ),
+        pytest.param(
+            ["test-data-asset1", "test-data-asset2"],
+            [
+                "retrieve-fail-asset-1",
+                "retrieve-fail-asset-2",
+                "metric-fail-asset-1",
+                "metric-fail-asset-2",
+                "schema-fail-asset-1",
+                "schema-fail-asset-2",
+            ],
+            [
+                "Failed to retrieve asset: retrieve-fail-asset-1",
+                "Failed to retrieve asset: retrieve-fail-asset-2",
+                "One or more metrics failed to compute.",
+                "One or more metrics failed to compute.",
+                "Failed to add expectation to suite: test-suite",
+                "Failed to add expectation to suite: test-suite",
+            ],
+            "Only displaying the first 5 errors. There is 1 additional error.",
+            "Failed to generate schema change expectations for 6 of the 8 assets.",
+            id="Multiple assets passing, multiple assets failing, one more than max display errors",
+        ),
+        # More than one more than max errors to display
+        pytest.param(
+            ["test-data-asset1", "test-data-asset2"],
+            [
+                "retrieve-fail-asset-1",
+                "retrieve-fail-asset-2",
+                "metric-fail-asset-1",
+                "metric-fail-asset-2",
+                "schema-fail-asset-1",
+                "schema-fail-asset-2",
+                "schema-fail-asset-3",
+                "schema-fail-asset-4",
+                "schema-fail-asset-5",
+            ],
+            [
+                "Failed to retrieve asset: retrieve-fail-asset-1",
+                "Failed to retrieve asset: retrieve-fail-asset-2",
+                "One or more metrics failed to compute.",
+                "One or more metrics failed to compute.",
+                "Failed to add expectation to suite: test-suite",
+                "Failed to add expectation to suite: test-suite",
+                "Failed to add expectation to suite: test-suite",
+                "Failed to add expectation to suite: test-suite",
+                "Failed to add expectation to suite: test-suite",
+            ],
+            "Only displaying the first 5 errors. There are 4 additional errors.",
+            "Failed to generate schema change expectations for 9 of the 11 assets.",
+            id="Multiple assets passing, multiple assets failing, more than max display errors",
         ),
     ],
 )
@@ -442,6 +496,7 @@ def test_succeeding_and_failing_assets_together(
     failing_data_asset_names: list[str],
     failing_data_asset_error_messages: list[str],
     expected_error_message: str,
+    expected_truncation_message: str,
 ):
     # setup
     mock_metric_repository = mocker.Mock(spec=MetricRepository)
@@ -471,6 +526,8 @@ def test_succeeding_and_failing_assets_together(
 
     # These are part of the same message
     assert expected_error_message in str(e.value)
+    if expected_truncation_message:
+        assert expected_truncation_message in str(e.value)
     for idx, asset_name in enumerate(failing_data_asset_names):
         assert f"Asset: {asset_name}" in str(e.value)
         assert failing_data_asset_error_messages[idx] in str(e.value)

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -344,10 +344,25 @@ def test_action_failure_in_get_metrics(
         assert "One or more metrics failed to compute." in str(e.value)
 
 
+@pytest.mark.parametrize(
+    "data_asset_names, expected_error_message",
+    [
+        (
+            ["test-data-asset1"],
+            "Failed to generate schema change expectations for 1 of the 1 assets.",
+        ),
+        (
+            ["test-data-asset1", "test-data-asset2"],
+            "Failed to generate schema change expectations for 2 of the 2 assets.",
+        ),
+    ],
+)
 def test_action_failure_in_add_schema_change_expectation(
     mock_response_failed_schema_change,
     mock_context: CloudDataContext,
     mocker: MockerFixture,
+    data_asset_names: list[str],
+    expected_error_message: str,
 ):
     # setup
     mock_metric_repository = mocker.Mock(spec=MetricRepository)
@@ -369,13 +384,14 @@ def test_action_failure_in_add_schema_change_expectation(
                 type="generate_schema_change_expectations_request.received",
                 organization_id=uuid.uuid4(),
                 datasource_name="test-datasource",
-                data_assets=["data-asset1"],
+                data_assets=data_asset_names,
                 create_expectations=True,
             ),
             id="test-id",
         )
 
     # These are part of the same message
-    assert "Failed to generate schema change expectations for 1 of the 1 assets." in str(e.value)
-    assert "Failed to add expectation to suite: test-suite" in str(e.value)
-    assert "Asset: data-asset1" in str(e.value)
+    assert expected_error_message in str(e.value)
+    for asset_name in data_asset_names:
+        assert f"Asset: {asset_name}" in str(e.value)
+        assert "Failed to add expectation to suite: test-suite" in str(e.value)

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -256,22 +256,22 @@ def test_action_failure_in_retrieve_asset_from_asset_name(
     )
 
     # run the action
-    return_value = action.run(
-        event=GenerateSchemaChangeExpectationsEvent(
-            type="generate_schema_change_expectations_request.received",
-            organization_id=uuid.uuid4(),
-            datasource_name="test-datasource",
-            data_assets=["data-asset1"],
-            create_expectations=True,
-        ),
-        id="test-id",
-    )
+    with pytest.raises(PartialSchemaChangeExpectationError) as e:
+        action.run(
+            event=GenerateSchemaChangeExpectationsEvent(
+                type="generate_schema_change_expectations_request.received",
+                organization_id=uuid.uuid4(),
+                datasource_name="test-datasource",
+                data_assets=["data-asset1"],
+                create_expectations=True,
+            ),
+            id="test-id",
+        )
 
-    assert len(return_value.created_resources) == 0
-    assert return_value.type == "generate_schema_change_expectations_request.received"
-    # both of these are part of the same message
-    assert "asset_name: data-asset1 failed with error" in caplog.text
-    assert "Failed to retrieve asset: data-asset1" in caplog.text
+    # These are part of the same message
+    assert "Failed to generate schema change expectations for 1 of the 1 assets." in str(e.value)
+    assert "Asset: data-asset1" in str(e.value)
+    assert "Failed to retrieve asset: data-asset1" in str(e.value)
 
 
 def test_action_failure_in_get_metrics(

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -399,17 +399,19 @@ def test_action_failure_in_add_schema_change_expectation(
 
 
 @pytest.mark.parametrize(
-    "succeeding_data_asset_names, failing_data_asset_names, expected_error_message",
+    "succeeding_data_asset_names, failing_data_asset_names, failing_data_asset_error_messages, expected_error_message",
     [
         pytest.param(
             ["test-data-asset1"],
             ["retrieve-fail-asset-1"],
+            ["Failed to retrieve asset: retrieve-fail-asset-1"],
             "Failed to generate schema change expectations for 1 of the 2 assets.",
             id="Single asset passing, single asset failing",
         ),
         pytest.param(
             ["test-data-asset1", "test-data-asset2"],
             ["retrieve-fail-asset-1"],
+            ["Failed to retrieve asset: retrieve-fail-asset-1"],
             "Failed to generate schema change expectations for 1 of the 3 assets.",
             id="Multiple assets passing, single asset failing",
         ),
@@ -420,6 +422,12 @@ def test_action_failure_in_add_schema_change_expectation(
                 "retrieve-fail-asset-2",
                 "metric-fail-asset-1",
                 "metric-fail-asset-2",
+            ],
+            [
+                "Failed to retrieve asset: retrieve-fail-asset-1",
+                "Failed to retrieve asset: retrieve-fail-asset-2",
+                "One or more metrics failed to compute.",
+                "One or more metrics failed to compute.",
             ],
             "Failed to generate schema change expectations for 4 of the 6 assets.",
             id="Multiple assets passing, multiple assets failing",
@@ -432,6 +440,7 @@ def test_succeeding_and_failing_assets_together(
     mocker: MockerFixture,
     succeeding_data_asset_names: list[str],
     failing_data_asset_names: list[str],
+    failing_data_asset_error_messages: list[str],
     expected_error_message: str,
 ):
     # setup
@@ -462,6 +471,6 @@ def test_succeeding_and_failing_assets_together(
 
     # These are part of the same message
     assert expected_error_message in str(e.value)
-    for asset_name in failing_data_asset_names:
+    for idx, asset_name in enumerate(failing_data_asset_names):
         assert f"Asset: {asset_name}" in str(e.value)
-        # assert "Failed to add expectation to suite: test-suite" in str(e.value)
+        assert failing_data_asset_error_messages[idx] in str(e.value)

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -290,22 +290,22 @@ def test_action_failure_in_get_metrics(
         organization_id=uuid.uuid4(),
     )
     # run the action
-    return_value = action.run(
-        event=GenerateSchemaChangeExpectationsEvent(
-            type="generate_schema_change_expectations_request.received",
-            organization_id=uuid.uuid4(),
-            datasource_name="test-datasource",
-            data_assets=["data-asset1"],
-            create_expectations=True,
-        ),
-        id="test-id",
-    )
+    with pytest.raises(PartialSchemaChangeExpectationError) as e:
+        action.run(
+            event=GenerateSchemaChangeExpectationsEvent(
+                type="generate_schema_change_expectations_request.received",
+                organization_id=uuid.uuid4(),
+                datasource_name="test-datasource",
+                data_assets=["data-asset1"],
+                create_expectations=True,
+            ),
+            id="test-id",
+        )
 
-    assert len(return_value.created_resources) == 0
-    assert return_value.type == "generate_schema_change_expectations_request.received"
-    # both of these are part of the same message
-    assert "asset_name: data-asset1 failed with error" in caplog.text
-    assert "One or more metrics failed to compute." in caplog.text
+    # These are part of the same message
+    assert "Failed to generate schema change expectations for 1 of the 1 assets." in str(e.value)
+    assert "Asset: data-asset1" in str(e.value)
+    assert "One or more metrics failed to compute." in str(e.value)
 
 
 def test_action_failure_in_add_schema_change_expectation(
@@ -339,6 +339,7 @@ def test_action_failure_in_add_schema_change_expectation(
             id="test-id",
         )
 
+    # These are part of the same message
     assert "Failed to generate schema change expectations for 1 of the 1 assets." in str(e.value)
     assert "Failed to add expectation to suite: test-suite" in str(e.value)
     assert "Asset: data-asset1" in str(e.value)

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -239,8 +239,25 @@ def test_generate_schema_change_expectations_action_success(
     assert return_value.type == "generate_schema_change_expectations_request.received"
 
 
+@pytest.mark.parametrize(
+    "data_asset_names, expected_error_message",
+    [
+        (
+            ["test-data-asset1"],
+            "Failed to generate schema change expectations for 1 of the 1 assets.",
+        ),
+        (
+            ["test-data-asset1", "test-data-asset2"],
+            "Failed to generate schema change expectations for 2 of the 2 assets.",
+        ),
+    ],
+)
 def test_action_failure_in_retrieve_asset_from_asset_name(
-    mock_response_failed_asset, mock_context: CloudDataContext, mocker: MockerFixture, caplog
+    mock_response_failed_asset,
+    mock_context: CloudDataContext,
+    mocker: MockerFixture,
+    data_asset_names: list[str],
+    expected_error_message: str,
 ):
     # setup
     mock_metric_repository = mocker.Mock(spec=MetricRepository)
@@ -262,16 +279,17 @@ def test_action_failure_in_retrieve_asset_from_asset_name(
                 type="generate_schema_change_expectations_request.received",
                 organization_id=uuid.uuid4(),
                 datasource_name="test-datasource",
-                data_assets=["data-asset1"],
+                data_assets=data_asset_names,
                 create_expectations=True,
             ),
             id="test-id",
         )
 
     # These are part of the same message
-    assert "Failed to generate schema change expectations for 1 of the 1 assets." in str(e.value)
-    assert "Asset: data-asset1" in str(e.value)
-    assert "Failed to retrieve asset: data-asset1" in str(e.value)
+    assert expected_error_message in str(e.value)
+    for asset_name in data_asset_names:
+        assert f"Asset: {asset_name}" in str(e.value)
+        assert f"Failed to retrieve asset: {asset_name}" in str(e.value)
 
 
 def test_action_failure_in_get_metrics(

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -34,9 +34,30 @@ pytestmark = pytest.mark.unit
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.fixture
+def mock_metrics_list() -> list[TableMetric]:
+    return [
+        TableMetric(
+            batch_id="batch_id",
+            metric_name="table.columns",
+            value=["col1", "col2"],
+            exception=None,
+        ),
+        TableMetric(
+            batch_id="batch_id",
+            metric_name="table.column_types",
+            value=[
+                {"name": "col1", "type": "INT"},
+                {"name": "col2", "type": "INT"},
+            ],
+            exception=None,
+        ),
+    ]
+
+
 # https://docs.pytest.org/en/7.1.x/how-to/monkeypatch.html
 @pytest.fixture
-def mock_response_success(monkeypatch):
+def mock_response_success(monkeypatch, mock_metrics_list: list[TableMetric]):
     def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
         return TableAsset(
             name="test-data-asset",
@@ -45,25 +66,7 @@ def mock_response_success(monkeypatch):
         )
 
     def mock_metrics(self, data_asset: DataAsset):
-        return MetricRun(
-            metrics=[
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.columns",
-                    value=["col1", "col2"],
-                    exception=None,
-                ),
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.column_types",
-                    value=[
-                        {"name": "col1", "type": "INT"},
-                        {"name": "col2", "type": "INT"},
-                    ],
-                    exception=None,
-                ),
-            ]
-        )
+        return MetricRun(metrics=mock_metrics_list)
 
     def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
         return gx_expectations.ExpectTableColumnsToMatchSet(
@@ -82,30 +85,12 @@ def mock_response_success(monkeypatch):
 
 
 @pytest.fixture
-def mock_response_failed_asset(monkeypatch):
+def mock_response_failed_asset(monkeypatch, mock_metrics_list: list[TableMetric]):
     def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
         raise RuntimeError(f"Failed to retrieve asset: {asset_name}")  # noqa: TRY003 # following pattern in code
 
     def mock_metrics(self, data_asset: DataAsset):
-        return MetricRun(
-            metrics=[
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.columns",
-                    value=["col1", "col2"],
-                    exception=None,
-                ),
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.column_types",
-                    value=[
-                        {"name": "col1", "type": "INT"},
-                        {"name": "col2", "type": "INT"},
-                    ],
-                    exception=None,
-                ),
-            ]
-        )
+        return MetricRun(metrics=mock_metrics_list)
 
     def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
         return gx_expectations.ExpectTableColumnsToMatchSet(
@@ -152,7 +137,7 @@ def mock_response_failed_metrics(monkeypatch):
 
 
 @pytest.fixture
-def mock_response_failed_schema_change(monkeypatch):
+def mock_response_failed_schema_change(monkeypatch, mock_metrics_list: list[TableMetric]):
     def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
         return TableAsset(
             name="test-data-asset",
@@ -161,25 +146,7 @@ def mock_response_failed_schema_change(monkeypatch):
         )
 
     def mock_metrics(self, data_asset: DataAsset):
-        return MetricRun(
-            metrics=[
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.columns",
-                    value=["col1", "col2"],
-                    exception=None,
-                ),
-                TableMetric(
-                    batch_id="batch_id",
-                    metric_name="table.column_types",
-                    value=[
-                        {"name": "col1", "type": "INT"},
-                        {"name": "col2", "type": "INT"},
-                    ],
-                    exception=None,
-                ),
-            ]
-        )
+        return MetricRun(metrics=mock_metrics_list)
 
     def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
         raise RuntimeError("Failed to add expectation to suite: test-suite")  # noqa: TRY003 # following pattern in code


### PR DESCRIPTION
We need to surface errors if they occur while we are adding expectations for the schema detection DQ issue. Errors could occur for some, none or all assets. We want to be able to surface the number of errors, the number of attempted assets, and at least a summary of how many errors were encountered. 

Note: Currently the max number of error messages shown is 5, but this can be adjusted. Also the rendering is not showing line breaks, only spacing. We should consider addressing that but maybe in a follow up PR as this PR is already somewhat large and the action is not yet active.

### Full list:
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/000b5588-d57a-451c-864e-aa285373550a">


### Truncated list:
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/ed8e08db-6f7d-4977-93a8-cacb0057e12a">
