### PR TITLE
Change wording in error message

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -40,7 +40,7 @@ LOGGER.setLevel(logging.DEBUG)
 class PartialSchemaChangeExpectationError(GXAgentError):
     def __init__(self, assets_with_errors: list[str], assets_attempted: int):
         message_header = f"Unable to fetch schemas for {len(assets_with_errors)} of {assets_attempted} Data Assets."
-        errors = " ,".join(assets_with_errors)
+        errors = ", ".join(assets_with_errors)
         message_footer = "Check your connection details, delete and recreate these Data Assets."
         message = f"{message_header}\n- {errors}\n{message_footer}"
         super().__init__(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241126.0.dev0"
+version = "20241126.0.dev2"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_generate_schema_change_expectations_action.py
+++ b/tests/agent/actions/test_generate_schema_change_expectations_action.py
@@ -85,84 +85,6 @@ def mock_response_success(monkeypatch, mock_metrics_list: list[TableMetric]):
 
 
 @pytest.fixture
-def mock_response_failed_asset(monkeypatch, mock_metrics_list: list[TableMetric]):
-    def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
-        raise RuntimeError(f"Failed to retrieve asset: {asset_name}")  # noqa: TRY003 # following pattern in code
-
-    def mock_metrics(self, data_asset: DataAsset):
-        return MetricRun(metrics=mock_metrics_list)
-
-    def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
-        return gx_expectations.ExpectTableColumnsToMatchSet(
-            column_set=["col1", "col2"], id=str(uuid.uuid4())
-        )
-
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction, "_retrieve_asset_from_asset_name", mock_data_asset
-    )
-    monkeypatch.setattr(GenerateSchemaChangeExpectationsAction, "_get_metrics", mock_metrics)
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction,
-        "_add_schema_change_expectation",
-        mock_schema_change_expectation,
-    )
-
-
-@pytest.fixture
-def mock_response_failed_metrics(monkeypatch):
-    def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
-        return TableAsset(
-            name="test-data-asset",
-            table_name="test_table",
-            schema_name="test_schema",
-        )
-
-    def mock_metrics(self, data_asset: DataAsset):
-        raise RuntimeError("One or more metrics failed to compute.")  # noqa: TRY003 # following pattern in code
-
-    def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
-        return gx_expectations.ExpectTableColumnsToMatchSet(
-            column_set=["col1", "col2"], id=str(uuid.uuid4())
-        )
-
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction, "_retrieve_asset_from_asset_name", mock_data_asset
-    )
-    monkeypatch.setattr(GenerateSchemaChangeExpectationsAction, "_get_metrics", mock_metrics)
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction,
-        "_add_schema_change_expectation",
-        mock_schema_change_expectation,
-    )
-
-
-@pytest.fixture
-def mock_response_failed_schema_change(monkeypatch, mock_metrics_list: list[TableMetric]):
-    def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
-        return TableAsset(
-            name="test-data-asset",
-            table_name="test_table",
-            schema_name="test_schema",
-        )
-
-    def mock_metrics(self, data_asset: DataAsset):
-        return MetricRun(metrics=mock_metrics_list)
-
-    def mock_schema_change_expectation(self, metric_run: MetricRun, expectation_suite_name: str):
-        raise RuntimeError("Failed to add expectation to suite: test-suite")  # noqa: TRY003 # following pattern in code
-
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction, "_retrieve_asset_from_asset_name", mock_data_asset
-    )
-    monkeypatch.setattr(GenerateSchemaChangeExpectationsAction, "_get_metrics", mock_metrics)
-    monkeypatch.setattr(
-        GenerateSchemaChangeExpectationsAction,
-        "_add_schema_change_expectation",
-        mock_schema_change_expectation,
-    )
-
-
-@pytest.fixture
 def mock_multi_asset_success_and_failure(monkeypatch, mock_metrics_list: list[TableMetric]):
     def mock_data_asset(self, event: GenerateSchemaChangeExpectationsEvent, asset_name: str):
         if "retrieve-fail" in asset_name:
@@ -246,171 +168,13 @@ def test_generate_schema_change_expectations_action_success(
 
 
 @pytest.mark.parametrize(
-    "data_asset_names, expected_error_message",
-    [
-        (
-            ["test-data-asset1"],
-            "Failed to generate schema change expectations for 1 of the 1 assets.",
-        ),
-        (
-            ["test-data-asset1", "test-data-asset2"],
-            "Failed to generate schema change expectations for 2 of the 2 assets.",
-        ),
-    ],
-)
-def test_action_failure_in_retrieve_asset_from_asset_name(
-    mock_response_failed_asset,
-    mock_context: CloudDataContext,
-    mocker: MockerFixture,
-    data_asset_names: list[str],
-    expected_error_message: str,
-):
-    # setup
-    mock_metric_repository = mocker.Mock(spec=MetricRepository)
-    mock_batch_inspector = mocker.Mock(spec=BatchInspector)
-
-    action = GenerateSchemaChangeExpectationsAction(
-        context=mock_context,
-        metric_repository=mock_metric_repository,
-        batch_inspector=mock_batch_inspector,
-        base_url="",
-        auth_key="",
-        organization_id=uuid.uuid4(),
-    )
-
-    # run the action
-    with pytest.raises(PartialSchemaChangeExpectationError) as e:
-        action.run(
-            event=GenerateSchemaChangeExpectationsEvent(
-                type="generate_schema_change_expectations_request.received",
-                organization_id=uuid.uuid4(),
-                datasource_name="test-datasource",
-                data_assets=data_asset_names,
-                create_expectations=True,
-            ),
-            id="test-id",
-        )
-
-    # These are part of the same message
-    assert expected_error_message in str(e.value)
-    for asset_name in data_asset_names:
-        assert f"Asset: {asset_name}" in str(e.value)
-        assert f"Failed to retrieve asset: {asset_name}" in str(e.value)
-
-
-@pytest.mark.parametrize(
-    "data_asset_names, expected_error_message",
-    [
-        (
-            ["test-data-asset1"],
-            "Failed to generate schema change expectations for 1 of the 1 assets.",
-        ),
-        (
-            ["test-data-asset1", "test-data-asset2"],
-            "Failed to generate schema change expectations for 2 of the 2 assets.",
-        ),
-    ],
-)
-def test_action_failure_in_get_metrics(
-    mock_response_failed_metrics,
-    mock_context: CloudDataContext,
-    mocker: MockerFixture,
-    data_asset_names: list[str],
-    expected_error_message: str,
-):
-    # setup
-    mock_metric_repository = mocker.Mock(spec=MetricRepository)
-    mock_batch_inspector = mocker.Mock(spec=BatchInspector)
-
-    action = GenerateSchemaChangeExpectationsAction(
-        context=mock_context,
-        metric_repository=mock_metric_repository,
-        batch_inspector=mock_batch_inspector,
-        base_url="",
-        auth_key="",
-        organization_id=uuid.uuid4(),
-    )
-    # run the action
-    with pytest.raises(PartialSchemaChangeExpectationError) as e:
-        action.run(
-            event=GenerateSchemaChangeExpectationsEvent(
-                type="generate_schema_change_expectations_request.received",
-                organization_id=uuid.uuid4(),
-                datasource_name="test-datasource",
-                data_assets=data_asset_names,
-                create_expectations=True,
-            ),
-            id="test-id",
-        )
-
-    # These are part of the same message
-    assert expected_error_message in str(e.value)
-    for asset_name in data_asset_names:
-        assert f"Asset: {asset_name}" in str(e.value)
-        assert "One or more metrics failed to compute." in str(e.value)
-
-
-@pytest.mark.parametrize(
-    "data_asset_names, expected_error_message",
-    [
-        (
-            ["test-data-asset1"],
-            "Failed to generate schema change expectations for 1 of the 1 assets.",
-        ),
-        (
-            ["test-data-asset1", "test-data-asset2"],
-            "Failed to generate schema change expectations for 2 of the 2 assets.",
-        ),
-    ],
-)
-def test_action_failure_in_add_schema_change_expectation(
-    mock_response_failed_schema_change,
-    mock_context: CloudDataContext,
-    mocker: MockerFixture,
-    data_asset_names: list[str],
-    expected_error_message: str,
-):
-    # setup
-    mock_metric_repository = mocker.Mock(spec=MetricRepository)
-    mock_batch_inspector = mocker.Mock(spec=BatchInspector)
-
-    action = GenerateSchemaChangeExpectationsAction(
-        context=mock_context,
-        metric_repository=mock_metric_repository,
-        batch_inspector=mock_batch_inspector,
-        base_url="",
-        auth_key="",
-        organization_id=uuid.uuid4(),
-    )
-
-    # run the action
-    with pytest.raises(PartialSchemaChangeExpectationError) as e:
-        action.run(
-            event=GenerateSchemaChangeExpectationsEvent(
-                type="generate_schema_change_expectations_request.received",
-                organization_id=uuid.uuid4(),
-                datasource_name="test-datasource",
-                data_assets=data_asset_names,
-                create_expectations=True,
-            ),
-            id="test-id",
-        )
-
-    # These are part of the same message
-    assert expected_error_message in str(e.value)
-    for asset_name in data_asset_names:
-        assert f"Asset: {asset_name}" in str(e.value)
-        assert "Failed to add expectation to suite: test-suite" in str(e.value)
-
-
-@pytest.mark.parametrize(
     "succeeding_data_asset_names, failing_data_asset_names, failing_data_asset_error_messages, expected_error_message, expected_truncation_message",
     [
         pytest.param(
             ["test-data-asset1"],
             ["retrieve-fail-asset-1"],
             ["Failed to retrieve asset: retrieve-fail-asset-1"],
-            "Failed to generate schema change expectations for 1 of the 2 assets.",
+            "Unable to fetch schemas for 1 of 2 Data Assets.",
             "",
             id="Single asset passing, single asset failing",
         ),
@@ -418,7 +182,7 @@ def test_action_failure_in_add_schema_change_expectation(
             ["test-data-asset1", "test-data-asset2"],
             ["retrieve-fail-asset-1"],
             ["Failed to retrieve asset: retrieve-fail-asset-1"],
-            "Failed to generate schema change expectations for 1 of the 3 assets.",
+            "Unable to fetch schemas for 1 of 3 Data Assets.",
             "",
             id="Multiple assets passing, single asset failing",
         ),
@@ -436,33 +200,10 @@ def test_action_failure_in_add_schema_change_expectation(
                 "One or more metrics failed to compute.",
                 "One or more metrics failed to compute.",
             ],
-            "Failed to generate schema change expectations for 4 of the 6 assets.",
+            "Unable to fetch schemas for 4 of 6 Data Assets.",
             "",
             id="Multiple assets passing, multiple assets failing",
         ),
-        pytest.param(
-            ["test-data-asset1", "test-data-asset2"],
-            [
-                "retrieve-fail-asset-1",
-                "retrieve-fail-asset-2",
-                "metric-fail-asset-1",
-                "metric-fail-asset-2",
-                "schema-fail-asset-1",
-                "schema-fail-asset-2",
-            ],
-            [
-                "Failed to retrieve asset: retrieve-fail-asset-1",
-                "Failed to retrieve asset: retrieve-fail-asset-2",
-                "One or more metrics failed to compute.",
-                "One or more metrics failed to compute.",
-                "Failed to add expectation to suite: test-suite",
-                "Failed to add expectation to suite: test-suite",
-            ],
-            "Failed to generate schema change expectations for 6 of the 8 assets.",
-            "Only displaying the first 5 errors. There is 1 additional error.",
-            id="Multiple assets passing, multiple assets failing, one more than max display errors",
-        ),
-        # More than one more than max errors to display
         pytest.param(
             ["test-data-asset1", "test-data-asset2"],
             [
@@ -487,7 +228,7 @@ def test_action_failure_in_add_schema_change_expectation(
                 "Failed to add expectation to suite: test-suite",
                 "Failed to add expectation to suite: test-suite",
             ],
-            "Failed to generate schema change expectations for 9 of the 11 assets.",
+            "Unable to fetch schemas for 9 of 11 Data Assets.",
             "Only displaying the first 5 errors. There are 4 additional errors.",
             id="Multiple assets passing, multiple assets failing, more than max display errors",
         ),
@@ -529,7 +270,7 @@ def test_succeeding_and_failing_assets_together(
             id="test-id",
         )
 
-    # These are part of the same message
+    # These are part of same message
     assert expected_error_message in str(e.value)
     if expected_truncation_message:
         assert expected_truncation_message in str(e.value)
@@ -538,5 +279,5 @@ def test_succeeding_and_failing_assets_together(
         # So we just check that the error messages are in the exception message
         # if there is no truncation message.
         for idx, asset_name in enumerate(failing_data_asset_names):
-            assert f"Asset: {asset_name}" in str(e.value)
+            assert asset_name in str(e.value)
             assert failing_data_asset_error_messages[idx] in str(e.value)


### PR DESCRIPTION
Change the wording to match the designs. Remove the truncation. Followup from https://github.com/great-expectations/cloud/pull/564

Example message created using the code in this PR (working on the line breaks / formatting separately):
<img width="985" alt="image" src="https://github.com/user-attachments/assets/7572b8a2-3b1f-4c75-9495-66773aa92082">


