### PR TITLE
Use bullet point in error to match design

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -42,7 +42,7 @@ class PartialSchemaChangeExpectationError(GXAgentError):
         message_header = f"Unable to fetch schemas for {len(assets_with_errors)} of {assets_attempted} Data Assets."
         errors = ", ".join(assets_with_errors)
         message_footer = "Check your connection details, delete and recreate these Data Assets."
-        message = f"{message_header}\n- {errors}\n{message_footer}"
+        message = f"{message_header}\n\u2022 {errors}\n{message_footer}"
         super().__init__(message)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241126.0.dev2"
+version = "20241126.0.dev3"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Tiny change to use a bullet point instead of a dash.

Before:
![image](https://github.com/user-attachments/assets/cdfadb2d-30dd-4be9-81bf-a510eedaa94c)

After:
![image](https://github.com/user-attachments/assets/c73171e5-39dc-4373-89ec-76b7395b84f4)
