### PR TITLE
Disable progress bars in agent by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,7 @@ RUN apt-get remove -y \
 # Disable analytics in OSS
 ENV GX_ANALYTICS_ENABLED=false
 
+# Disable progress bars
+ENV ENABLE_PROGRESS_BARS=false
+
 ENTRYPOINT ["poetry", "run", "gx-agent"]


### PR DESCRIPTION
Final piece for ZELDA-1124. This will disable progress bars on the agent by default, which is what we want for GX-managed agents. 