### PR TITLE
Reenable integration test

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -71,29 +71,29 @@ class GenerateSchemaChangeExpectationsAction(AgentAction[GenerateSchemaChangeExp
     @override
     def run(self, event: GenerateSchemaChangeExpectationsEvent, id: str) -> ActionResult:
         created_resources: list[CreatedResource] = []
-        assets_with_errors: list[str] = []
+        # assets_with_errors: list[str] = []
         for asset_name in event.data_assets:
-            try:
-                data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
-                metric_run, metric_run_id = self._get_metrics(data_asset)
+            # try:
+            data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
+            metric_run, metric_run_id = self._get_metrics(data_asset)
 
-                expectation_id = self._add_schema_change_expectation(
-                    metric_run=metric_run, asset_id=data_asset.id
-                )
-                created_resources.append(
-                    CreatedResource(resource_id=str(metric_run_id), type="MetricRun")
-                )
-                created_resources.append(
-                    CreatedResource(resource_id=str(expectation_id), type="Expectation")
-                )
-            except Exception:
-                assets_with_errors.append(asset_name)
-
-        if assets_with_errors:
-            raise PartialSchemaChangeExpectationError(
-                assets_with_errors=assets_with_errors,
-                assets_attempted=len(event.data_assets),
+            expectation_id = self._add_schema_change_expectation(
+                metric_run=metric_run, asset_id=data_asset.id
             )
+            created_resources.append(
+                CreatedResource(resource_id=str(metric_run_id), type="MetricRun")
+            )
+            created_resources.append(
+                CreatedResource(resource_id=str(expectation_id), type="Expectation")
+            )
+        #     except Exception:
+        #         assets_with_errors.append(asset_name)
+        #
+        # if assets_with_errors:
+        #     raise PartialSchemaChangeExpectationError(
+        #         assets_with_errors=assets_with_errors,
+        #         assets_attempted=len(event.data_assets),
+        #     )
 
         return ActionResult(
             id=id,

--- a/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_schema_change_expectations_action.py
@@ -71,29 +71,29 @@ class GenerateSchemaChangeExpectationsAction(AgentAction[GenerateSchemaChangeExp
     @override
     def run(self, event: GenerateSchemaChangeExpectationsEvent, id: str) -> ActionResult:
         created_resources: list[CreatedResource] = []
-        # assets_with_errors: list[str] = []
+        assets_with_errors: list[str] = []
         for asset_name in event.data_assets:
-            # try:
-            data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
-            metric_run, metric_run_id = self._get_metrics(data_asset)
+            try:
+                data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
+                metric_run, metric_run_id = self._get_metrics(data_asset)
 
-            expectation_id = self._add_schema_change_expectation(
-                metric_run=metric_run, asset_id=data_asset.id
+                expectation_id = self._add_schema_change_expectation(
+                    metric_run=metric_run, asset_id=data_asset.id
+                )
+                created_resources.append(
+                    CreatedResource(resource_id=str(metric_run_id), type="MetricRun")
+                )
+                created_resources.append(
+                    CreatedResource(resource_id=str(expectation_id), type="Expectation")
+                )
+            except Exception:
+                assets_with_errors.append(asset_name)
+
+        if assets_with_errors:
+            raise PartialSchemaChangeExpectationError(
+                assets_with_errors=assets_with_errors,
+                assets_attempted=len(event.data_assets),
             )
-            created_resources.append(
-                CreatedResource(resource_id=str(metric_run_id), type="MetricRun")
-            )
-            created_resources.append(
-                CreatedResource(resource_id=str(expectation_id), type="Expectation")
-            )
-        #     except Exception:
-        #         assets_with_errors.append(asset_name)
-        #
-        # if assets_with_errors:
-        #     raise PartialSchemaChangeExpectationError(
-        #         assets_with_errors=assets_with_errors,
-        #         assets_attempted=len(event.data_assets),
-        #     )
 
         return ActionResult(
             id=id,

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -55,7 +55,7 @@ def seed_and_cleanup_test_data(context: CloudDataContext):
     )
 
     # Mark the validation as gx_managed
-    engine = sa.create_engine("postgresql://postgres:postgres@db:5432/mercury")
+    engine = sa.create_engine("postgresql://api:postgres@localhost:5432/mercury")
     with engine.begin() as conn:
         query = f"UPDATE validations SET gx_managed=true WHERE id='{validation.id}'"
         conn.execute(sa.text(query))

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -55,7 +55,7 @@ def seed_and_cleanup_test_data(context: CloudDataContext):
     )
 
     # Mark the validation as gx_managed
-    engine = sa.create_engine("postgresql://api:postgres@localhost:5432/mercury")
+    engine = sa.create_engine("postgresql://postgres:postgres@localhost:5432/mercury")
     with engine.begin() as conn:
         query = f"UPDATE validations SET gx_managed=true WHERE id='{validation.id}'"
         conn.execute(sa.text(query))
@@ -96,7 +96,7 @@ def org_id_env_var_local():
 
 @pytest.fixture(scope="module")
 def cloud_base_url_local() -> str:
-    return "http://localhost:7000"
+    return "http://localhost:5000"
 
 
 @pytest.fixture

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -94,11 +94,6 @@ def org_id_env_var_local():
     return "0ccac18e-7631-4bdd-8a42-3c35cce574c6"
 
 
-@pytest.fixture(scope="module")
-def cloud_base_url_local() -> str:
-    return "http://localhost:5000"
-
-
 @pytest.fixture
 def token_env_var_local():
     return os.environ.get("GX_CLOUD_ACCESS_TOKEN")
@@ -108,7 +103,7 @@ def test_running_schema_change_expectation_action(
     context: CloudDataContext,
     user_api_token_headers_org_admin_sc_org,
     org_id_env_var_local: str,
-    cloud_base_url_local: str,
+    cloud_base_url: str,
     token_env_var_local: str,
     seed_and_cleanup_test_data,
 ):
@@ -124,7 +119,7 @@ def test_running_schema_change_expectation_action(
 
     action = GenerateSchemaChangeExpectationsAction(
         context=context,
-        base_url=cloud_base_url_local,
+        base_url=cloud_base_url,
         organization_id=uuid.UUID(org_id_env_var_local),
         auth_key=token_env_var_local,
     )

--- a/tests/integration/actions/test_generate_schema_change_expectations.py
+++ b/tests/integration/actions/test_generate_schema_change_expectations.py
@@ -55,7 +55,7 @@ def seed_and_cleanup_test_data(context: CloudDataContext):
     )
 
     # Mark the validation as gx_managed
-    engine = sa.create_engine("postgresql://postgres:postgres@localhost:5432/mercury")
+    engine = sa.create_engine("postgresql://postgres:postgres@db:5432/mercury")
     with engine.begin() as conn:
         query = f"UPDATE validations SET gx_managed=true WHERE id='{validation.id}'"
         conn.execute(sa.text(query))
@@ -104,9 +104,6 @@ def token_env_var_local():
     return os.environ.get("GX_CLOUD_ACCESS_TOKEN")
 
 
-@pytest.mark.skip(
-    "This test fails due to a connection error when attempting to call the backend. It is a problem with the test setup, not the code which was demoed, and this test passes locally."
-)
 def test_running_schema_change_expectation_action(
     context: CloudDataContext,
     user_api_token_headers_org_admin_sc_org,


### PR DESCRIPTION
This test was failing because it could not connect to the backend at port 7000. Once we realized that both v0 and v1 are being served on port 5000 via this PR: https://github.com/great-expectations/cloud/commit/b84f86b7405b0b86bf63e2ea7986cb48eb674485, it meant that this test should also use port 5000. It also uses the common fixture instead of a test specific fixture.