### PR TITLE
Rename `_add_data_quality_check_expectation` to be `_add_schema_change_expectation`, which is more accurate

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -79,7 +79,7 @@ class GenerateDataQualityCheckExpectationsAction(
                 data_asset = self._retrieve_asset_from_asset_name(event, asset_name)
                 metric_run, metric_run_id = self._get_metrics(data_asset)
 
-                expectation_id = self._add_data_quality_check_expectation(
+                expectation_id = self._add_schema_change_expectation(
                     metric_run=metric_run, asset_id=data_asset.id
                 )
                 created_resources.append(
@@ -131,7 +131,7 @@ class GenerateDataQualityCheckExpectationsAction(
 
         return metric_run, metric_run_id
 
-    def _add_data_quality_check_expectation(self, metric_run: MetricRun, asset_id: UUID) -> UUID:
+    def _add_schema_change_expectation(self, metric_run: MetricRun, asset_id: UUID) -> UUID:
         expectation = gx_expectations.ExpectTableColumnsToMatchSet(
             column_set=metric_run.metrics[0].value
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241212.1"
+version = "20241213.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
+++ b/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
@@ -124,7 +124,7 @@ def mock_multi_asset_success_and_failure(monkeypatch, mock_metrics_list: list[Ta
     monkeypatch.setattr(GenerateDataQualityCheckExpectationsAction, "_get_metrics", mock_metrics)
     monkeypatch.setattr(
         GenerateDataQualityCheckExpectationsAction,
-        "_add_data_quality_check_expectation",
+        "_add_schema_change_expectation",
         mock_schema_change_expectation,
     )
 

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -66,6 +66,7 @@ def test_running_draft_datasource_config_action(
         "system_users",
         "checkpoints",
         "organizations",
+        "organizations_auth0_orgs",
         "metric_runs",
         "users",
         "auth0_users",

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -49,6 +49,7 @@ def test_running_list_table_names_action(
         "datasources",
         "expectation_suites",
         "organizations",
+        "organizations_auth0_orgs",
         "api_tokens",
         "users",
         "agent_job_created_resources",


### PR DESCRIPTION
* renaming an internal method to `_add_schema_change_expectation`  which will allow more autogenerated Expectations 