### PR TITLE
Allow GX-Runner to set Correlation ID for Sentry Issues

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -268,7 +268,7 @@ class GXAgent:
         """Helper method to get the auth key. Overridden in GX-Runner."""
         return self._config.gx_cloud_access_token
 
-    def _set_sentry_tags(self, event_context: EventContext) -> None:
+    def _set_sentry_tags(self, correlation_id: str | None) -> None:
         """Used by GX-Runner to set tags for Sentry logging. No-op in the Agent."""
         pass
 
@@ -312,7 +312,7 @@ class GXAgent:
             },
         )
 
-        self._set_sentry_tags(event_context)
+        self._set_sentry_tags(event_context.correlation_id)
 
         handler = EventHandler(context=data_context)
         # This method might raise an exception. Allow it and handle in _handle_event_as_thread_exit

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -283,7 +283,6 @@ class GXAgent:
         """
         # warning:  this method will not be executed in the main thread
 
-        # this is the branching point
         data_context = self.get_data_context(event_context=event_context)
         # ensure that great_expectations.http requests to GX Cloud include the job_id/correlation_id
         self._set_http_session_headers(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241223.0"
+version = "20250107.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
* PR to allow for the Runner to set Correlation ID for Sentry Issues without too much code duplication.  That feature is enabled here - https://github.com/greatexpectationslabs/gx-runner/pull/286
* Adds call to `_set_sentry_tags()` method in `_handle_event` which is shared by both Agent and Runner, but in the Agent, this is a no-op. 