### PR TITLE
Add temporary logging to determine if jobs are being re-queued

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -234,7 +234,15 @@ class GXAgent:
             event_context: An Event with related properties and actions.
         """
         if self._reject_correlation_id(event_context.correlation_id) is True:
-            # this event has been redelivered too many times - remove it from circulation
+            logging.info(
+                "This event has exceeded its redelivery limit, removing from circulation",
+                extra={
+                    "event_type": event_context.event.type,
+                    "correlation_id": event_context.correlation_id,
+                    "organization_id": event_context.organization.id,
+                    "schedule_id": event_context.event.schedule_id,
+                },
+            )
             event_context.processed_with_failures()
             return
         elif self._can_accept_new_task() is not True:

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -240,7 +240,9 @@ class GXAgent:
                     "event_type": event_context.event.type,
                     "correlation_id": event_context.correlation_id,
                     "organization_id": event_context.organization.id,
-                    "schedule_id": event_context.event.schedule_id,
+                    "schedule_id": event_context.event.schedule_id
+                    if isinstance(event_context.event, ScheduledEventBase)
+                    else None,
                 },
             )
             event_context.processed_with_failures()
@@ -252,7 +254,9 @@ class GXAgent:
                     "event_type": event_context.event.type,
                     "correlation_id": event_context.correlation_id,
                     "organization_id": event_context.organization.id,
-                    "schedule_id": event_context.event.schedule_id,
+                    "schedule_id": event_context.event.schedule_id
+                    if isinstance(event_context.event, ScheduledEventBase)
+                    else None,
                 },
             )
             # request that this message is redelivered later

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -239,7 +239,7 @@ class GXAgent:
                 extra={
                     "event_type": event_context.event.type,
                     "correlation_id": event_context.correlation_id,
-                    "organization_id": event_context.organization.id,
+                    "organization_id": self.get_organization_id(event_context),
                     "schedule_id": event_context.event.schedule_id
                     if isinstance(event_context.event, ScheduledEventBase)
                     else None,
@@ -253,7 +253,7 @@ class GXAgent:
                 extra={
                     "event_type": event_context.event.type,
                     "correlation_id": event_context.correlation_id,
-                    "organization_id": event_context.organization.id,
+                    "organization_id": self.get_organization_id(event_context),
                     "schedule_id": event_context.event.schedule_id
                     if isinstance(event_context.event, ScheduledEventBase)
                     else None,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -234,7 +234,7 @@ class GXAgent:
             event_context: An Event with related properties and actions.
         """
         if self._reject_correlation_id(event_context.correlation_id) is True:
-            logging.info(
+            LOGGER.info(
                 "This event has exceeded its redelivery limit, removing from circulation",
                 extra={
                     "event_type": event_context.event.type,
@@ -246,7 +246,7 @@ class GXAgent:
             event_context.processed_with_failures()
             return
         elif self._can_accept_new_task() is not True:
-            logging.info(
+            LOGGER.info(
                 "Cannot accept new task, redelivering",
                 extra={
                     "event_type": event_context.event.type,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -238,6 +238,15 @@ class GXAgent:
             event_context.processed_with_failures()
             return
         elif self._can_accept_new_task() is not True:
+            logging.info(
+                "Cannot accept new task, redelivering",
+                extra={
+                    "event_type": event_context.event.type,
+                    "correlation_id": event_context.correlation_id,
+                    "organization_id": event_context.organization.id,
+                    "schedule_id": event_context.event.schedule_id,
+                },
+            )
             # request that this message is redelivered later
             loop = asyncio.get_event_loop()
             # store a reference the task to ensure it isn't garbage collected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20241223.0"
+version = "20250108.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Part of work to investigate missing/inconsistent schedules ([ZELDA-1194](https://greatexpectations.atlassian.net/jira/software/c/projects/ZELDA/boards/85?assignee=712020%3Aa6524cc2-4928-4a00-924a-33f2eccde893&selectedIssue=ZELDA-1194)).
See Slack thread [here](https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1736356433906939) for more context.  

[ZELDA-1194]: https://greatexpectations.atlassian.net/browse/ZELDA-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ