### PR TITLE
Add ability to override the AMQP host and port

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -483,7 +483,6 @@ class GXAgent:
             netloc = f"{parsed.username}:{parsed.password}@{parsed.hostname}:{env_vars.amqp_port_override}"
             parsed = parsed._replace(netloc=netloc)  # documented in urllib docs
         connection_string = parsed.geturl()
-        print(f"\n\nconnection_string: {connection_string}\n\n")
 
         try:
             # pydantic will coerce the url to the correct type

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -475,7 +475,9 @@ class GXAgent:
         # to localhost, for example.
         parsed = urlparse(connection_string)
         if env_vars.amqp_host_override:
-            netloc = f"{parsed.username}:{parsed.password}@{env_vars.amqp_host_override}:{parsed.port}"
+            netloc = (
+                f"{parsed.username}:{parsed.password}@{env_vars.amqp_host_override}:{parsed.port}"
+            )
             parsed = parsed._replace(netloc=netloc)  # documented in urllib docs
         if env_vars.amqp_port_override:
             netloc = f"{parsed.username}:{parsed.password}@{parsed.hostname}:{env_vars.amqp_port_override}"

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from collections import defaultdict
-from concurrent.futures import Future
-from importlib.metadata import version as metadata_version
-
 import asyncio
 import logging
 import sys
 import traceback
 import warnings
+from collections import defaultdict
+from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
+from importlib.metadata import version as metadata_version
 from typing import TYPE_CHECKING, Any, Callable, Final, Literal
 from urllib.parse import urljoin, urlparse
 from uuid import UUID
+
 import orjson
 import requests
 from great_expectations.core.http import create_session
@@ -476,10 +476,10 @@ class GXAgent:
         parsed = urlparse(connection_string)
         if env_vars.amqp_host_override:
             netloc = f"{parsed.username}:{parsed.password}@{env_vars.amqp_host_override}:{parsed.port}"
-            parsed = parsed._replace(netloc=netloc)  # noqa  # documented in urllib docs
+            parsed = parsed._replace(netloc=netloc)  # documented in urllib docs
         if env_vars.amqp_port_override:
             netloc = f"{parsed.username}:{parsed.password}@{parsed.hostname}:{env_vars.amqp_port_override}"
-            parsed = parsed._replace(netloc=netloc)  # noqa  # documented in urllib docs
+            parsed = parsed._replace(netloc=netloc)  # documented in urllib docs
         connection_string = parsed.geturl()
         print(f"\n\nconnection_string: {connection_string}\n\n")
 

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
+from collections import defaultdict
+from concurrent.futures import Future
+from importlib.metadata import version as metadata_version
+
 import asyncio
 import logging
 import sys
 import traceback
 import warnings
-from collections import defaultdict
-from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
-from importlib.metadata import version as metadata_version
 from typing import TYPE_CHECKING, Any, Callable, Final, Literal
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from uuid import UUID
-
 import orjson
 import requests
 from great_expectations.core.http import create_session
@@ -470,6 +470,18 @@ class GXAgent:
         json_response = response.json()
         queue = json_response["queue"]
         connection_string = json_response["connection_string"]
+
+        # if overrides are set, we update the connection string. This is useful for local development to set the host
+        # to localhost, for example.
+        parsed = urlparse(connection_string)
+        if env_vars.amqp_host_override:
+            netloc = f"{parsed.username}:{parsed.password}@{env_vars.amqp_host_override}:{parsed.port}"
+            parsed = parsed._replace(netloc=netloc)  # noqa  # documented in urllib docs
+        if env_vars.amqp_port_override:
+            netloc = f"{parsed.username}:{parsed.password}@{parsed.hostname}:{env_vars.amqp_port_override}"
+            parsed = parsed._replace(netloc=netloc)  # noqa  # documented in urllib docs
+        connection_string = parsed.geturl()
+        print(f"\n\nconnection_string: {connection_string}\n\n")
 
         try:
             # pydantic will coerce the url to the correct type

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Optional
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from pydantic.v1 import AnyUrl, BaseSettings, ValidationError
 
@@ -11,8 +12,8 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_access_token: str
     enable_progress_bars: bool = True
 
-    amqp_host_override: str | None = None
-    amqp_port_override: int | None = None
+    amqp_host_override: Optional[str] = None
+    amqp_port_override: Optional[int] = None
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from pydantic.v1 import AnyUrl, BaseSettings, ValidationError
 

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -11,6 +11,9 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_access_token: str
     enable_progress_bars: bool = True
 
+    amqp_host_override: str | None = None
+    amqp_port_override: int | None = None
+
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """
         Custom __init__ to prevent type error when relying on environment variables.

--- a/great_expectations_cloud/agent/config.py
+++ b/great_expectations_cloud/agent/config.py
@@ -13,8 +13,8 @@ class GxAgentEnvVars(BaseSettings):
     gx_cloud_access_token: str
     enable_progress_bars: bool = True
 
-    amqp_host_override: Optional[str] = None
-    amqp_port_override: Optional[int] = None
+    amqp_host_override: Optional[str] = None  # noqa: UP007  # pipe not working with 3.9
+    amqp_port_override: Optional[int] = None  # noqa: UP007  # pipe not working with 3.9
 
     def __init__(self, **overrides: str | AnyUrl) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250107.0.dev0"
+version = "20250109.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from uuid import UUID
+
 import pytest
 
 from great_expectations_cloud.agent.actions import DraftDatasourceConfigAction

--- a/tests/integration/actions/test_draft_datasource_config_action.py
+++ b/tests/integration/actions/test_draft_datasource_config_action.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from uuid import UUID
-
 import pytest
 
 from great_expectations_cloud.agent.actions import DraftDatasourceConfigAction
@@ -49,6 +48,8 @@ def test_running_draft_datasource_config_action(
         "agent_job_created_resources",
         "agent_job_source_resources",
         "agent_jobs",
+        "alert_emails",
+        "asset_alert_emails",
         "asset_refs",
         "expectations",
         "expectation_changes",

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from uuid import UUID
+
 import pytest
 
 from great_expectations_cloud.agent.actions import ListTableNamesAction

--- a/tests/integration/actions/test_list_table_names.py
+++ b/tests/integration/actions/test_list_table_names.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from uuid import UUID
-
 import pytest
 
 from great_expectations_cloud.agent.actions import ListTableNamesAction
@@ -44,6 +43,8 @@ def test_running_list_table_names_action(
         "alembic_version",
         "organization_api_tokens",
         "asset_refs",
+        "alert_emails",
+        "asset_alert_emails",
         "checkpoints",
         "data_context_variables",
         "datasources",


### PR DESCRIPTION
When running on "bare metal" with the backend services running in docker, you can run

```sh
export GX_...=...
export AMQP_HOST_OVERRIDE=localhost
poetry run gx-agent
```