### PR TITLE
Upgrade poetry in github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-${{ steps.python-version.outputs.PYTHON_VERSION }}-1 # increment to reset cache
+          key: poetry-${{ steps.python-version.outputs.PYTHON_VERSION }}-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync
@@ -66,13 +66,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-${{ matrix.python-version  }}-1 # increment to reset cache
+          key: poetry-${{ matrix.python-version  }}-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync
@@ -147,13 +147,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-${{ matrix.python-version  }}-1 # increment to reset cache
+          key: poetry-${{ matrix.python-version  }}-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync
@@ -219,13 +219,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-3.10-1 # increment to reset cache
+          key: poetry-3.10-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync --only dev
@@ -274,13 +274,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-3.8-1 # increment to reset cache
+          key: poetry-3.8-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Get version from pyproject.toml for PR
         id: pr_version
@@ -325,13 +325,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-3.8-1 # increment to reset cache
+          key: poetry-3.8-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync # Needed for calling invoke

--- a/.github/workflows/containerize-agent.yaml
+++ b/.github/workflows/containerize-agent.yaml
@@ -30,13 +30,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-1 # increment to reset cache
+          key: poetry-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --with dev,sql --sync

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-1 # increment to reset cache
+          key: poetry-2 # increment to reset cache
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.5
+          version: 2.0.0
 
       - name: Install dependencies
         run: poetry install --sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250109.0"
+version = "20250110.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
With poetry pinned and the caches invalidated, it looks like poetry 2.0.0 is working at least in the ci workflow. This PR upgrades poetry everywhere to 2.0.0, and after it merges if there is an issue with the pypi workflow we can downgrade there.