### PR TITLE
Set RabbitMQ prefetch count to one

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -238,6 +238,17 @@ class GXAgent:
             event_context.processed_with_failures()
             return
         elif self._can_accept_new_task() is not True:
+            LOGGER.warning(
+                "Cannot accept new task, redelivering.",
+                extra={
+                    "event_type": event_context.event.type,
+                    "correlation_id": event_context.correlation_id,
+                    "organization_id": self.get_organization_id(event_context),
+                    "schedule_id": event_context.event.schedule_id
+                    if isinstance(event_context.event, ScheduledEventBase)
+                    else None,
+                },
+            )
             # request that this message is redelivered later
             loop = asyncio.get_event_loop()
             # store a reference the task to ensure it isn't garbage collected

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -222,6 +222,8 @@ class AsyncRabbitMQClient:
         LOGGER.debug("Connection to RabbitMQ has been opened")
         on_channel_open = partial(self._on_channel_open, queue=queue, on_message=on_message)
         connection.channel(on_open_callback=on_channel_open)
+        # set RabbitMQ prefetch count to equal the max_threads value in the GX Agent's ThreadPoolExecutor
+        connection.channel.basic_qos(prefetch_count=1)
 
     def _on_connection_open_error(
         self, _unused_connection: AsyncioConnection, reason: pika.Exception

--- a/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
+++ b/great_expectations_cloud/agent/message_service/asyncio_rabbit_mq_client.py
@@ -183,6 +183,8 @@ class AsyncRabbitMQClient:
         """Consume from a channel with the on_message callback."""
         LOGGER.debug("Issuing consumer-related RPC commands")
         channel.add_on_cancel_callback(self._on_consumer_canceled)
+        # set RabbitMQ prefetch count to equal the max_threads value in the GX Agent's ThreadPoolExecutor
+        channel.basic_qos(prefetch_count=1)
         self._consumer_tag = channel.basic_consume(queue=queue, on_message_callback=on_message)
 
     def _on_consumer_canceled(self, method_frame: Basic.Cancel) -> None:
@@ -222,8 +224,6 @@ class AsyncRabbitMQClient:
         LOGGER.debug("Connection to RabbitMQ has been opened")
         on_channel_open = partial(self._on_channel_open, queue=queue, on_message=on_message)
         connection.channel(on_open_callback=on_channel_open)
-        # set RabbitMQ prefetch count to equal the max_threads value in the GX Agent's ThreadPoolExecutor
-        connection.channel.basic_qos(prefetch_count=1)
 
     def _on_connection_open_error(
         self, _unused_connection: AsyncioConnection, reason: pika.Exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250110.0.dev2"
+version = "20250117.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
This PR addresses the scheduler issues discussed [here](https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1736356433906939) by setting the RabbitMQ `prefetch_count` to 1 (since the GX Agent's `ThreadPoolExecutor` has a value of `max_threads=1`). This means that each worker can only hold one unacknowledged message at a time. More about the prefetch count [here](https://www.rabbitmq.com/docs/consumer-prefetch). 

Verified that this is working as expected locally. Without the prefetch count set, we see the warning logs when multiple validations are triggered manually from the UI: 
```
[INFO] great_expectations_cloud.agent.agent: The GX Agent is ready.
[DEBUG] great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client: Connection to RabbitMQ has been opened
[DEBUG] great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client: Channel opened
[DEBUG] great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client: Issuing consumer-related RPC commands
[DEBUG] great_expectations_cloud.agent.agent: Setting session headers for GX Cloud
[INFO] great_expectations_cloud.agent.agent: Updating status
[INFO] great_expectations_cloud.agent.agent: Status updated
[INFO] great_expectations_cloud.agent.agent: Starting job
[INFO] great_expectations_cloud.agent.agent: Cannot accept new task, redelivering.
[INFO] great_expectations_cloud.agent.agent: Cannot accept new task, redelivering.
[INFO] great_expectations_cloud.agent.agent: Cannot accept new task, redelivering.
Calculating Metrics: 0it [00:00, ?it/s]
[INFO] great_expectations_cloud.agent.agent: Completed job
[INFO] great_expectations_cloud.agent.agent: Updating status
```

After adding the prefetch count, these logs go away, which means we are correctly waiting until the first job is finished/acknowledged before a new one is being pushed to the worker. 