### PR TITLE
Fix MQ Auth race condition

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -19,7 +19,6 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from great_expectations.data_context.data_context.context_factory import get_context
-from great_expectations.exceptions import exceptions as gx_exception
 from great_expectations.data_context.types.base import ProgressBarsConfig
 from pika.adapters.utils.connection_workflow import (
     AMQPConnectorException,

--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -19,6 +19,7 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
 from great_expectations.data_context.data_context.context_factory import get_context
+from great_expectations.exceptions import exceptions as gx_exception
 from great_expectations.data_context.types.base import ProgressBarsConfig
 from pika.adapters.utils.connection_workflow import (
     AMQPConnectorException,
@@ -140,7 +141,7 @@ class GXAgent:
     _PYPI_GREAT_EXPECTATIONS_PACKAGE_NAME = "great_expectations"
 
     def __init__(self: Self):
-        self._config: GXAgentConfig | None = None
+        self._config = self._create_config()
 
         agent_version: str = self.get_current_gx_agent_version()
         great_expectations_version: str = self._get_current_great_expectations_version()
@@ -469,7 +470,7 @@ class GXAgent:
         return should_reject
 
     def _get_config(self, force_refresh: bool = False) -> GXAgentConfig:
-        if force_refresh or not self._config:
+        if force_refresh:
             self._config = self._create_config()
         return self._config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250130.0"
+version = "20250131.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Callable, Literal
 from unittest.mock import call
 
 import pytest
+from pytest_mock import MockerFixture
 import requests
 import responses
 from great_expectations.exceptions import exceptions as gx_exception
@@ -30,6 +31,7 @@ from great_expectations_cloud.agent.agent import (
 from great_expectations_cloud.agent.constants import USER_AGENT_HEADER, HeaderName
 from great_expectations_cloud.agent.exceptions import GXAgentConfigError
 from great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client import (
+    AsyncRabbitMQClient,
     ClientError,
 )
 from great_expectations_cloud.agent.message_service.subscriber import (
@@ -146,9 +148,15 @@ def get_context(mocker):
 
 @pytest.fixture
 def client(mocker):
-    """Patch for agent.RabbitMQClient"""
+    """Patch for agent.AsyncRabbitMQClient"""
     client = mocker.patch("great_expectations_cloud.agent.agent.AsyncRabbitMQClient")
     return client
+
+
+@pytest.fixture
+def mock_client_run(mocker: MockerFixture):
+    """Patch for agent.AsyncRabbitMQClient"""
+    return mocker.patch.object(AsyncRabbitMQClient, "run")
 
 
 @pytest.fixture

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Callable, Literal
 from unittest.mock import call
 
 import pytest
-from pytest_mock import MockerFixture
 import requests
 import responses
 from great_expectations.exceptions import exceptions as gx_exception
@@ -50,6 +49,8 @@ from great_expectations_cloud.agent.models import (
 from tests.agent.conftest import FakeSubscriber
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from tests.agent.conftest import DataContextConfigTD
 
 


### PR DESCRIPTION
## Context
We thought we fixed this with ZEL-505 a long while back, but apparently we didn't. We're spewing TOOONS of logs about connection refused.

## The problems
 It appears that there are a few issues:

* We refresh creds after catching exceptions of a few types, but not the type that actually gets raised (subtle naming difference here). We now include the correct base type in our `except`. Pretty sure this was the actual reason things didn't get resolved.
* Even if we refreshed the creds, that happens before we wait to retry. This gap between getting creds and using them increases our chance of error. Note that this changes the flow around where we get/set `self._config` on the agent. _config is not optional, and anyplace that accesses it calls `self._get_config`.
* I added some jitter to the exponential backoff to hopefully make race conditions less likely.
* We're seeing a lot of retries in the logs, which makes it look like tenacity is ignoring that we try to stop after 3 attempts. Maybe something else is making this happen? I'm still not sure.

## Sample logs
```
[
    {
      "args": [],
      "levelname": "ERROR",
      "filename": "connection.py",
      "module": "connection",
      "exc_info": null,
      "stack_info": null,
      "funcName": "_on_stream_terminated",
      "created": 1738348417.013373,
      "relativeCreated": 74509054.2242527,
      "event": "Connection closed while authenticating indicating a probable authentication error",
      "level": "ERROR",
      "logger": "pika.connection",
      "timestamp": "2025-01-31T18:33:37.013373+00:00",
      "environment": "production",
      "service_name": "gx-agent"
    },
    {
      "args": [],
      "levelname": "DEBUG",
      "filename": "asyncio_rabbit_mq_client.py",
      "module": "asyncio_rabbit_mq_client",
      "exc_info": null,
      "stack_info": null,
      "funcName": "_reconnect",
      "created": 1738348417.0135212,
      "relativeCreated": 74509054.37254906,
      "event": "Preparing client to reconnect",
      "level": "DEBUG",
      "logger": "great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client",
      "timestamp": "2025-01-31T18:33:37.013521+00:00",
      "environment": "production",
      "service_name": "gx-agent"
    },
    {
      "args": [],
      "levelname": "DEBUG",
      "filename": "asyncio_rabbit_mq_client.py",
      "module": "asyncio_rabbit_mq_client",
      "exc_info": null,
      "stack_info": null,
      "funcName": "stop",
      "created": 1738348417.013589,
      "relativeCreated": 74509054.44025993,
      "event": "Shutting down the connection to RabbitMQ.",
      "level": "DEBUG",
      "logger": "great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client",
      "timestamp": "2025-01-31T18:33:37.013589+00:00",
      "environment": "production",
      "service_name": "gx-agent"
    },
    {
      "args": [],
      "levelname": "DEBUG",
      "filename": "asyncio_rabbit_mq_client.py",
      "module": "asyncio_rabbit_mq_client",
      "exc_info": null,
      "stack_info": null,
      "funcName": "stop",
      "created": 1738348417.013643,
      "relativeCreated": 74509054.49438095,
      "event": "The connection to RabbitMQ has been shut down.",
      "level": "DEBUG",
      "logger": "great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client",
      "timestamp": "2025-01-31T18:33:37.013643+00:00",
      "environment": "production",
      "service_name": "gx-agent"
    },
    {
      "args": [],
      "levelname": "ERROR",
      "filename": "asyncio_rabbit_mq_client.py",
      "module": "asyncio_rabbit_mq_client",
      "exc_info": null,
      "stack_info": null,
      "funcName": "_log_pika_exception",
      "created": 1738348417.013694,
      "relativeCreated": 74509054.54540253,
      "reason": "ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'",
      "event": "Connection open failed",
      "level": "ERROR",
      "logger": "great_expectations_cloud.agent.message_service.asyncio_rabbit_mq_client",
      "timestamp": "2025-01-31T18:33:37.013694+00:00",
      "environment": "production",
      "service_name": "gx-agent"
    },
    {
      "args": "(AMQPConnectorAMQPHandshakeError: ProbableAuthenticationError: Client was disconnected at a connection stage indicating a probable authentication error: (\"ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'\",),)",
      "levelname": "'ERROR'",
      "filename": "'connection_workflow.py'",
      "module": "'connection_workflow'",
      "exc_info": "None",
      "stack_info": "None",
      "funcName": "'_report_completion_and_cleanup'",
      "created": "1738348417.013754",
      "relativeCreated": "74509054.60524559",
      "event": "'AMQPConnector - reporting failure: %r'",
      "level": "'ERROR'",
      "logger": "'pika.adapters.utils.connection_workflow'",
      "timestamp": "'2025-01-31T18:33:37.013754+00:00'",
      "environment": "'production'",
      "service_name": "'gx-agent'"
    },
    {
      "args": "(AMQPConnectionWorkflowFailed: 1 exceptions in all; last exception - AMQPConnectorAMQPHandshakeError: ProbableAuthenticationError: Client was disconnected at a connection stage indicating a probable authentication error: (\"ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'\",); first exception - None,)",
      "levelname": "'ERROR'",
      "filename": "'connection_workflow.py'",
      "module": "'connection_workflow'",
      "exc_info": "None",
      "stack_info": "None",
      "funcName": "'_report_completion_and_cleanup'",
      "created": "1738348417.0138443",
      "relativeCreated": "74509054.69560623",
      "event": "'AMQPConnectionWorkflow - reporting failure: %r'",
      "level": "'ERROR'",
      "logger": "'pika.adapters.utils.connection_workflow'",
      "timestamp": "'2025-01-31T18:33:37.013844+00:00'",
      "environment": "'production'",
      "service_name": "'gx-agent'"
    },
    {
      "args": "(AMQPConnectionWorkflowFailed: 1 exceptions in all; last exception - AMQPConnectorAMQPHandshakeError: ProbableAuthenticationError: Client was disconnected at a connection stage indicating a probable authentication error: (\"ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'\",); first exception - None,)",
      "levelname": "'ERROR'",
      "filename": "'base_connection.py'",
      "module": "'base_connection'",
      "exc_info": "None",
      "stack_info": "None",
      "funcName": "'_on_connection_workflow_done'",
      "created": "1738348417.0139244",
      "relativeCreated": "74509054.77571487",
      "event": "'Full-stack connection workflow failed: %r'",
      "level": "'ERROR'",
      "logger": "'pika.adapters.base_connection'",
      "timestamp": "'2025-01-31T18:33:37.013924+00:00'",
      "environment": "'production'",
      "service_name": "'gx-agent'"
    },
    {
      "args": "(AMQPConnectionWorkflowFailed: 1 exceptions in all; last exception - AMQPConnectorAMQPHandshakeError: ProbableAuthenticationError: Client was disconnected at a connection stage indicating a probable authentication error: (\"ConnectionClosedByBroker: (403) 'ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.'\",); first exception - None,)",
      "levelname": "'ERROR'",
      "filename": "'base_connection.py'",
      "module": "'base_connection'",
      "exc_info": "None",
      "stack_info": "None",
      "funcName": "'_handle_connection_workflow_failure'",
      "created": "1738348417.0139978",
      "relativeCreated": "74509054.8491478",
      "event": "'Self-initiated stack bring-up failed: %r'",
      "level": "'ERROR'",
      "logger": "'pika.adapters.base_connection'",
      "timestamp": "'2025-01-31T18:33:37.013998+00:00'",
      "environment": "'production'",
      "service_name": "'gx-agent'"
    }
  ]```