### PR TITLE
Add `selected_data_quality_issues` to `GenerateDataQualityCheckExpectationsEvent`

### DIFF
--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any, Literal, Optional, Union
 from uuid import UUID
 
+from great_expectations.expectations.metadata_types import DataQualityIssues
 from great_expectations.experimental.metric_repository.metrics import MetricTypes
 from pydantic.v1 import BaseModel, Extra, Field
 
@@ -109,6 +110,7 @@ class GenerateDataQualityCheckExpectationsEvent(EventBase):
     )
     datasource_name: str
     data_assets: Sequence[str]
+    selected_data_quality_issues: Sequence[DataQualityIssues] | None = None
 
 
 class RunRdAgentEvent(EventBase):

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -109,7 +109,6 @@ class GenerateDataQualityCheckExpectationsEvent(EventBase):
     )
     datasource_name: str
     data_assets: Sequence[str]
-    create_expectations: bool = False
 
 
 class RunRdAgentEvent(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250203.1"
+version = "20250203.2.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
+++ b/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
@@ -173,7 +173,6 @@ def test_generate_schema_change_expectations_action_success(
             organization_id=uuid.uuid4(),
             datasource_name="test-datasource",
             data_assets=data_asset_names,
-            create_expectations=True,
         ),
         id="test-id",
     )
@@ -263,7 +262,6 @@ def test_succeeding_and_failing_assets_together(
                 organization_id=uuid.uuid4(),
                 datasource_name="test-datasource",
                 data_assets=succeeding_data_asset_names + failing_data_asset_names,
-                create_expectations=True,
             ),
             id="test-id",
         )

--- a/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
+++ b/tests/agent/actions/test_generate_data_quality_check_expectations_action.py
@@ -173,6 +173,7 @@ def test_generate_schema_change_expectations_action_success(
             organization_id=uuid.uuid4(),
             datasource_name="test-datasource",
             data_assets=data_asset_names,
+            selected_data_quality_issues=None,
         ),
         id="test-id",
     )
@@ -262,6 +263,7 @@ def test_succeeding_and_failing_assets_together(
                 organization_id=uuid.uuid4(),
                 datasource_name="test-datasource",
                 data_assets=succeeding_data_asset_names + failing_data_asset_names,
+                selected_data_quality_issues=None,
             ),
             id="test-id",
         )

--- a/tests/integration/actions/test_generate_data_quality_check_expectations.py
+++ b/tests/integration/actions/test_generate_data_quality_check_expectations.py
@@ -112,6 +112,7 @@ def test_running_schema_change_expectation_action(
         datasource_name="local_mercury_db",
         data_assets=["local-mercury-db-checkpoints-table"],
         organization_id=uuid.UUID(org_id_env_var_local),
+        selected_data_quality_issues=None,
     )
 
     action = GenerateDataQualityCheckExpectationsAction(


### PR DESCRIPTION
Part of work for [Volume Change Detection](https://greatexpectations.atlassian.net/browse/GX-195). 

This PR adds `selected_data_quality_issues` to `GenerateDataQualityCheckExpectationsEvent`, and removes the unused `create_expectations` argument. 

Corresponding mercury PR [here](https://github.com/greatexpectationslabs/mercury/pull/4337). 