### PR TITLE
[MAINTENANCE] Pass user_agent_str to get_context

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -156,7 +156,10 @@ class GXAgent:
         with warnings.catch_warnings():
             # suppress warnings about GX version
             warnings.filterwarnings("ignore", message="You are using great_expectations version")
-            self._context: CloudDataContext = get_context(cloud_mode=True)
+            self._context: CloudDataContext = get_context(
+                cloud_mode=True,
+                user_agent_str=self.user_agent_str,
+            )
             self._configure_progress_bars(data_context=self._context)
         LOGGER.debug("DataContext is ready.")
 
@@ -667,6 +670,12 @@ class GXAgent:
             if isinstance(backend, GXCloudStoreBackend):
                 backend._session.headers.update(headers)
 
+    @property
+    def user_agent_str(self) -> str:
+        user_agent_header_prefix = self.get_user_agent_header()
+        agent_version = self._get_version()
+        return f"{user_agent_header_prefix}/{agent_version}"
+
     def _set_http_session_headers(
         self, data_context: CloudDataContext, correlation_id: str | None = None
     ) -> None:
@@ -682,9 +691,7 @@ class GXAgent:
         from great_expectations.core import http
 
         header_name = self.get_header_name()
-        user_agent_header_prefix = self.get_user_agent_header()
-        agent_version = self._get_version()
-        user_agent_header_value = f"{user_agent_header_prefix}/{agent_version}"
+        user_agent_header_value = self.user_agent_str
 
         LOGGER.debug(
             "Setting session headers for GX Cloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250226.0"
+version = "20250303.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250303.0.dev0"
+version = "20250304.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -6,7 +6,7 @@ import string
 import uuid
 from time import sleep
 from typing import TYPE_CHECKING, Callable, Literal
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import pytest
 import requests
@@ -244,7 +244,7 @@ def test_gx_agent_invalid_token(monkeypatch, set_required_env_vars: None):
 
 def test_gx_agent_initializes_cloud_context(get_context, gx_agent_config):
     GXAgent()
-    get_context.assert_called_with(cloud_mode=True)
+    get_context.assert_called_with(cloud_mode=True, user_agent_str=ANY)
 
 
 def test_gx_agent_run_starts_subscriber(get_context, subscriber, client, gx_agent_config):


### PR DESCRIPTION
We already send these in request headers from the agent, but for consistency with other repos, we're also initializing our analytics with it.