### PR TITLE
[FEATURE]: Add triangular_interpolation utility function

### DIFF
--- a/great_expectations_cloud/agent/__init__.py
+++ b/great_expectations_cloud/agent/__init__.py
@@ -3,3 +3,4 @@ from __future__ import annotations
 import great_expectations_cloud.agent.actions  # import actions to register them
 from great_expectations_cloud.agent.agent import GXAgent
 from great_expectations_cloud.agent.run import get_version, run_agent
+from great_expectations_cloud.agent.utils import triangular_interpolation

--- a/great_expectations_cloud/agent/utils.py
+++ b/great_expectations_cloud/agent/utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+INPUT_RANGE = (0.0, 1.0)
+OUTPUT_RANGE = (0.0, 10.0)
+ROUND_PRECISION = 1
+
+
+@dataclass
+class TriangularInterpolationOptions:
+    """Options for triangular interpolation."""
+
+    input_range: tuple[float, float] = INPUT_RANGE
+    output_range: tuple[float, float] = OUTPUT_RANGE
+    round_precision: int = ROUND_PRECISION
+
+
+def triangular_interpolation(
+    value: float, options: TriangularInterpolationOptions | None = None
+) -> float:
+    """
+    Maps a value between input range to a triangular pattern between output range.
+    Values between input_min-midpoint map from output_min to output_max linearly.
+    Values between midpoint-input_max map from output_max to output_min linearly.
+    The midpoint is automatically calculated as the middle of the input range.
+    Result is always rounded to the specified precision.
+
+    Args:
+        value (float): Input value between input_min and input_max
+        options (TriangularInterpolationOptions, optional): Configuration options for the interpolation.
+            If not provided, default values will be used.
+
+    Returns:
+        float: Interpolated value between output_min and output_max, rounded to specified precision
+    """
+    if options is None:
+        options = TriangularInterpolationOptions()
+
+    # Extract values from options for readability
+    input_min, input_max = options.input_range
+    output_min, output_max = options.output_range
+    round_precision = options.round_precision
+
+    # Calculate midpoint
+    midpoint = input_min + (input_max - input_min) / 2
+
+    # Ensure input is between input_min and input_max
+    clamped_value = max(input_min, min(input_max, value))
+
+    if clamped_value <= midpoint:
+        # First half: linear mapping from input_min→output_min to midpoint→output_max
+        normalized_value = (clamped_value - input_min) / (midpoint - input_min)
+        result = output_min + normalized_value * (output_max - output_min)
+    else:
+        # Second half: linear mapping from midpoint→output_max to input_max→output_min
+        normalized_value = (clamped_value - midpoint) / (input_max - midpoint)
+        result = output_max - normalized_value * (output_max - output_min)
+
+    # Round to specified precision
+    result = round(result, round_precision)
+
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250320.1.dev0"
+version = "20250324.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250320.0"
+version = "20250320.1.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"

--- a/tests/agent/test_utils.py
+++ b/tests/agent/test_utils.py
@@ -1,0 +1,66 @@
+import pytest
+
+from great_expectations_cloud.agent.utils import (
+    TriangularInterpolationOptions,
+    triangular_interpolation,
+)
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_output",
+    [
+        # Boundary values
+        (0.0, 0.0),  # Minimum value
+        (0.5, 10.0),  # Peak value
+        (1.0, 0.0),  # Maximum value
+        # First half range (0 to 0.5)
+        (0.1, 2.0),
+        (0.25, 5.0),
+        # Second half range (0.5 to 1)
+        (0.75, 5.0),
+        (0.9, 2.0),
+        # Outside range (should clamp)
+        (-0.5, 0.0),
+        (1.5, 0.0),
+        # Rounding to one decimal place
+        (0.123, 2.5),
+        (0.876, 2.5),
+    ],
+)
+def test_triangular_interpolation(input_value, expected_output):
+    assert triangular_interpolation(input_value) == expected_output
+
+
+def test_triangular_interpolation_custom_parameters():
+    """Test triangular interpolation with custom parameters using options object."""
+    # Test with custom input range (0-100) and output range (0-1)
+    options_100_to_1 = TriangularInterpolationOptions(
+        input_range=(0, 100),
+        output_range=(0, 1),
+        round_precision=2,
+    )
+
+    assert triangular_interpolation(value=0, options=options_100_to_1) == 0.0
+    assert triangular_interpolation(value=50, options=options_100_to_1) == 1.0
+    assert triangular_interpolation(value=100, options=options_100_to_1) == 0.0
+
+    # Test different rounding precision
+    options_precision = TriangularInterpolationOptions(round_precision=2)
+    assert triangular_interpolation(value=0.123, options=options_precision) == 2.46
+
+    # Test asymmetric ranges
+    options_asymmetric = TriangularInterpolationOptions(
+        input_range=(0, 10),
+        output_range=(0, 100),
+        round_precision=0,
+    )
+    assert triangular_interpolation(value=2, options=options_asymmetric) == 40
+
+    # Test with specific values for more complex ranges
+    options_shifted = TriangularInterpolationOptions(
+        input_range=(-1, 1),
+        output_range=(5, 15),
+    )
+    assert triangular_interpolation(value=0, options=options_shifted) == 15.0
+    assert triangular_interpolation(value=-1, options=options_shifted) == 5.0
+    assert triangular_interpolation(value=1, options=options_shifted) == 5.0


### PR DESCRIPTION
Added a triangle interpolation helper that maps values based on how close they are to 50% sparse data. It takes values between 0-1 and outputs between 0-10, creating a triangle pattern (0→0, 0.5→10, 1→0) and rounds to the nearest 0.1. You can adjust the input/output ranges through a configurable options object.

* Function lives in `great_expectations_cloud/agent/utils.py` with a dataclass for configuration options
* Tests verify it works with default settings, custom ranges, different rounding precision, and edge cases

This will be useful for our upcoming completeness change detection work.