### PR TITLE
Windowed completeness expectations should be +/- offset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250324.0.dev1"
+version = "20250326.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
- Adds a second window so that the expectation is +/- in cloud ui.
- Uses triangular interpolation result to determine expectation type
- Updates variable names for clarity.