### PR TITLE
Update setuptools and poetry in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV POETRY_CACHE_DIR=/tmp/pypoetry
 #   gcc: required to build psutil for arm64
 RUN apt-get update && apt-get install --no-install-recommends python3-dev=3.11.2-1+b1 gcc=4:12.2.0-3 -y && rm -rf /var/lib/apt/lists/*
 
-RUN pip --no-cache-dir install poetry==1.8.3
+RUN pip --no-cache-dir install setuptools==78.1.0 poetry==2.1.2
 
 COPY pyproject.toml poetry.lock ./
 


### PR DESCRIPTION
Updating in `pyproject.toml` was insufficient since `setuptools` lives outside the poetry enviornment.