### PR TITLE
Pass EventContext to methods setting sentry tags

### DIFF
--- a/great_expectations_cloud/agent/agent.py
+++ b/great_expectations_cloud/agent/agent.py
@@ -299,7 +299,7 @@ class GXAgent:
         """Helper method to get the auth key. Overridden in GX-Runner."""
         return self._get_config().gx_cloud_access_token
 
-    def _set_sentry_tags(self, correlation_id: str | None) -> None:
+    def _set_sentry_tags(self, even_context: EventContext) -> None:
         """Used by GX-Runner to set tags for Sentry logging. No-op in the Agent."""
         pass
 
@@ -342,7 +342,7 @@ class GXAgent:
             },
         )
 
-        self._set_sentry_tags(event_context.correlation_id)
+        self._set_sentry_tags(event_context)
 
         handler = EventHandler(context=data_context)
         # This method might raise an exception. Allow it and handle in _handle_event_as_thread_exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250416.0"
+version = "20250417.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
Passing the context will allow us to set more useful tags in sentry