### PR TITLE
Temporary fix to handle CCD error when column is empty

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -271,6 +271,10 @@ class GenerateDataQualityCheckExpectationsAction(
                 options = TriangularInterpolationOptions(
                     input_range=(0.0, float(row_count)), output_range=(0, 0.1), round_precision=5
                 )
+                if null_count is None:
+                    # TODO: this is a temporary fix to handle the case of an empty column, we should
+                    #  figure out why the COLUMN_NULL_COUNT metric is being returned as None instead of 0
+                    null_count = 0
                 interpolated_offset = max(
                     0.0001, round(triangular_interpolation(null_count, options), 5)
                 )

--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -247,7 +247,9 @@ class GenerateDataQualityCheckExpectationsAction(
             null_count = column.value
             row_count = table_row_count.value
             expectation: gx_expectations.Expectation
-            if null_count == 0:
+            if null_count == 0 or None:
+                # None handles the edge case of an empty table, we are making the assumption that future
+                # data should have non-null values
                 expectation = gx_expectations.ExpectColumnValuesToNotBeNull(
                     column=column_name, mostly=1
                 )
@@ -271,10 +273,6 @@ class GenerateDataQualityCheckExpectationsAction(
                 options = TriangularInterpolationOptions(
                     input_range=(0.0, float(row_count)), output_range=(0, 0.1), round_precision=5
                 )
-                if null_count is None:
-                    # TODO: this is a temporary fix to handle the case of an empty column, we should
-                    #  figure out why the COLUMN_NULL_COUNT metric is being returned as None instead of 0
-                    null_count = 0
                 interpolated_offset = max(
                     0.0001, round(triangular_interpolation(null_count, options), 5)
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250424.0"
+version = "20250430.0.dev0"
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]
 repository = "https://github.com/great-expectations/cloud"


### PR DESCRIPTION
This is a band aid solution so that we don't fail with [this](https://gx-cloud.sentry.io/issues/6509381994/?referrer=jira_integration) Sentry when a column is empty and a user wants to generate CCD expectations. We should figure out why the metric is being returned as `None` instead of `0`, but for now this will restore functionality to the UI. 