### PR TITLE
Only add completeness expectations to columns without coverage

### DIFF
--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -513,10 +513,10 @@ class GenerateDataQualityCheckExpectationsAction(
     ) -> list[ColumnMetric[int]]:
         try:
             columns_with_completeness_coverage = {
-                expectation.get("kwargs").get("column")  # type: ignore[union-attr]
+                expectation.get("config").get("kwargs").get("column")  # type: ignore[union-attr]
                 for expectation in pre_existing_completeness_change_expectations
             }
-        except TypeError as e:
+        except AttributeError as e:
             raise InvalidExpectationConfigurationError(str(e)) from e
         columns_without_completeness_coverage = [
             column

--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -115,7 +115,7 @@ class GenerateDataQualityCheckExpectationsAction(
                         self._get_current_anomaly_detection_coverage(data_asset.id)
                     )
 
-                    if self._should_add_volume_change_coverage(
+                    if self._should_add_volume_change_detection_coverage(
                         selected_data_quality_issues=selected_dqis,
                         pre_existing_anomaly_detection_coverage=pre_existing_anomaly_detection_coverage,
                     ):
@@ -129,7 +129,7 @@ class GenerateDataQualityCheckExpectationsAction(
                             )
                         )
 
-                    if self._should_add_schema_change_coverage(
+                    if self._should_add_schema_change_detection_coverage(
                         selected_data_quality_issues=selected_dqis,
                         pre_existing_anomaly_detection_coverage=pre_existing_anomaly_detection_coverage,
                     ):
@@ -242,7 +242,7 @@ class GenerateDataQualityCheckExpectationsAction(
                 response=response,
             ) from e
 
-    def _should_add_volume_change_coverage(
+    def _should_add_volume_change_detection_coverage(
         self,
         selected_data_quality_issues: list[DataQualityIssues],
         pre_existing_anomaly_detection_coverage: list[
@@ -251,10 +251,10 @@ class GenerateDataQualityCheckExpectationsAction(
     ) -> bool:
         return (
             DataQualityIssues.VOLUME in selected_data_quality_issues
-            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.VOLUME, [])) > 0
+            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.VOLUME, [])) == 0
         )
 
-    def _should_add_schema_change_coverage(
+    def _should_add_schema_change_detection_coverage(
         self,
         selected_data_quality_issues: list[DataQualityIssues],
         pre_existing_anomaly_detection_coverage: list[
@@ -263,7 +263,7 @@ class GenerateDataQualityCheckExpectationsAction(
     ) -> bool:
         return (
             DataQualityIssues.SCHEMA in selected_data_quality_issues
-            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.SCHEMA, [])) > 0
+            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.SCHEMA, [])) == 0
         )
 
     def _add_volume_change_expectation(self, asset_id: UUID | None, use_forecast: bool) -> UUID:

--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -379,6 +379,7 @@ class GenerateDataQualityCheckExpectationsAction(
                 column_name = column.column
                 null_count = column.value
                 row_count = table_row_count.value
+                expectation: gx_expectations.Expectation
 
                 unique_id = param_safe_unique_id(16)
                 min_param_name = f"{unique_id}_proportion_min"

--- a/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
+++ b/great_expectations_cloud/agent/actions/generate_data_quality_check_expectations_action.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import great_expectations.expectations as gx_expectations
 from great_expectations.core.http import create_session
-from great_expectations.exceptions import GXCloudError
+from great_expectations.exceptions import GXCloudError, InvalidExpectationConfigurationError
 from great_expectations.expectations.metadata_types import (
     DataQualityIssues,
 )
@@ -115,10 +115,9 @@ class GenerateDataQualityCheckExpectationsAction(
                         self._get_current_anomaly_detection_coverage(data_asset.id)
                     )
 
-                    if self._should_add_anomaly_detection_coverage_for_issue(
-                        DataQualityIssues.VOLUME,
-                        selected_dqis,
-                        pre_existing_anomaly_detection_coverage,
+                    if self._should_add_volume_change_coverage(
+                        selected_data_quality_issues=selected_dqis,
+                        pre_existing_anomaly_detection_coverage=pre_existing_anomaly_detection_coverage,
                     ):
                         volume_change_expectation_id = self._add_volume_change_expectation(
                             asset_id=data_asset.id,
@@ -130,10 +129,9 @@ class GenerateDataQualityCheckExpectationsAction(
                             )
                         )
 
-                    if self._should_add_anomaly_detection_coverage_for_issue(
-                        DataQualityIssues.SCHEMA,
-                        selected_dqis,
-                        pre_existing_anomaly_detection_coverage,
+                    if self._should_add_schema_change_coverage(
+                        selected_data_quality_issues=selected_dqis,
+                        pre_existing_anomaly_detection_coverage=pre_existing_anomaly_detection_coverage,
                     ):
                         schema_change_expectation_id = self._add_schema_change_expectation(
                             metric_run=metric_run, asset_id=data_asset.id
@@ -145,10 +143,16 @@ class GenerateDataQualityCheckExpectationsAction(
                         )
 
                     if DataQualityIssues.COMPLETENESS in selected_dqis:
+                        pre_existing_completeness_change_expectations = (
+                            pre_existing_anomaly_detection_coverage.get(
+                                DataQualityIssues.COMPLETENESS, []
+                            )
+                        )
                         completeness_change_expectation_ids = self._add_completeness_change_expectations(
                             metric_run=metric_run,
                             asset_id=data_asset.id,
                             expect_non_null_proportion_enabled=event.expect_non_null_proportion_enabled,
+                            pre_existing_completeness_change_expectations=pre_existing_completeness_change_expectations,
                         )
                         for exp_id in completeness_change_expectation_ids:
                             created_resources.append(
@@ -238,13 +242,29 @@ class GenerateDataQualityCheckExpectationsAction(
                 response=response,
             ) from e
 
-    def _should_add_anomaly_detection_coverage_for_issue(
+    def _should_add_volume_change_coverage(
         self,
-        issue: DataQualityIssues,
-        selected_dqis: Sequence[DataQualityIssues],
-        pre_existing_anomaly_detection_coverage: dict[DataQualityIssues, list[dict[Any, Any]]],
+        selected_data_quality_issues: list[DataQualityIssues],
+        pre_existing_anomaly_detection_coverage: list[
+            dict[Any, Any]
+        ],  # list of ExpectationConfiguration dicts
     ) -> bool:
-        return issue in selected_dqis and issue not in pre_existing_anomaly_detection_coverage
+        return (
+            DataQualityIssues.VOLUME in selected_data_quality_issues
+            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.VOLUME, [])) > 0
+        )
+
+    def _should_add_schema_change_coverage(
+        self,
+        selected_data_quality_issues: list[DataQualityIssues],
+        pre_existing_anomaly_detection_coverage: list[
+            dict[Any, Any]
+        ],  # list of ExpectationConfiguration dicts
+    ) -> bool:
+        return (
+            DataQualityIssues.SCHEMA in selected_data_quality_issues
+            and len(pre_existing_anomaly_detection_coverage.get(DataQualityIssues.SCHEMA, [])) > 0
+        )
 
     def _add_volume_change_expectation(self, asset_id: UUID | None, use_forecast: bool) -> UUID:
         unique_id = param_safe_unique_id(16)
@@ -323,6 +343,9 @@ class GenerateDataQualityCheckExpectationsAction(
         self,
         metric_run: MetricRun,
         asset_id: UUID | None,
+        pre_existing_completeness_change_expectations: list[
+            dict[Any, Any]
+        ],  # list of ExpectationConfiguration dicts
         expect_non_null_proportion_enabled: bool = False,
     ) -> list[UUID]:
         table_row_count = next(
@@ -330,7 +353,6 @@ class GenerateDataQualityCheckExpectationsAction(
             for metric in metric_run.metrics
             if metric.metric_name == MetricTypes.TABLE_ROW_COUNT
         )
-        expectation_ids = []
 
         if not table_row_count:
             raise RuntimeError("missing TABLE_ROW_COUNT metric")  # noqa: TRY003
@@ -345,14 +367,20 @@ class GenerateDataQualityCheckExpectationsAction(
         if not column_null_values_metric or len(column_null_values_metric) == 0:
             raise RuntimeError("missing COLUMN_NULL_COUNT metrics")  # noqa: TRY003
 
-        for column in column_null_values_metric:
-            column_name = column.column
-            null_count = column.value
-            row_count = table_row_count.value
-            expectation: gx_expectations.Expectation
+        expectation_ids = []
+        if expect_non_null_proportion_enabled:
+            # Single-expectation approach using ExpectColumnProportionOfNonNullValuesToBeBetween
+            # Expectations are only added to columns that do not have coverage
+            columns_missing_completeness_coverage = self._get_columns_missing_completeness_coverage(
+                column_null_values_metric=column_null_values_metric,
+                pre_existing_completeness_change_expectations=pre_existing_completeness_change_expectations,
+            )
+            for column in columns_missing_completeness_coverage:
+                column_name = column.column
+                null_count = column.value
+                row_count = table_row_count.value
+                expectation: gx_expectations.Expectation
 
-            if expect_non_null_proportion_enabled:
-                # Single-expectation approach using ExpectColumnProportionOfNonNullValuesToBeBetween
                 unique_id = param_safe_unique_id(16)
                 min_param_name = f"{unique_id}_proportion_min"
                 max_param_name = f"{unique_id}_proportion_max"
@@ -396,50 +424,57 @@ class GenerateDataQualityCheckExpectationsAction(
                     expectation=expectation, asset_id=asset_id
                 )
                 expectation_ids.append(expectation_id)
+        else:
             # Current two-expectation approach
-            elif null_count == 0 or None:
-                # None handles the edge case of an empty table, we are making the assumption that future
-                # data should have non-null values
-                expectation = gx_expectations.ExpectColumnValuesToNotBeNull(
-                    column=column_name, mostly=1
-                )
-                expectation_id = self._create_expectation_for_asset(
-                    expectation=expectation, asset_id=asset_id
-                )
-                expectation_ids.append(expectation_id)
-            elif null_count == row_count:
-                expectation = gx_expectations.ExpectColumnValuesToBeNull(
-                    column=column_name, mostly=1
-                )
-                expectation_id = self._create_expectation_for_asset(
-                    expectation=expectation, asset_id=asset_id
-                )
-                expectation_ids.append(expectation_id)
-            else:
-                # Create two separate expectations when null count is neither 0 nor 100%
-                unique_id_null = param_safe_unique_id(16)
-                unique_id_not_null = param_safe_unique_id(16)
+            for column in column_null_values_metric:
+                column_name = column.column
+                null_count = column.value
+                row_count = table_row_count.value
+                expectation: gx_expectations.Expectation
 
-                interpolated_offset = self._compute_triangular_interpolation_offset(
-                    value=null_count, input_range=(0.0, float(row_count))
-                )
+                if null_count == 0 or None:
+                    # None handles the edge case of an empty table, we are making the assumption that future
+                    # data should have non-null values
+                    expectation = gx_expectations.ExpectColumnValuesToNotBeNull(
+                        column=column_name, mostly=1
+                    )
+                    expectation_id = self._create_expectation_for_asset(
+                        expectation=expectation, asset_id=asset_id
+                    )
+                    expectation_ids.append(expectation_id)
+                elif null_count == row_count:
+                    expectation = gx_expectations.ExpectColumnValuesToBeNull(
+                        column=column_name, mostly=1
+                    )
+                    expectation_id = self._create_expectation_for_asset(
+                        expectation=expectation, asset_id=asset_id
+                    )
+                    expectation_ids.append(expectation_id)
+                else:
+                    # Create two separate expectations when null count is neither 0 nor 100%
+                    unique_id_null = param_safe_unique_id(16)
+                    unique_id_not_null = param_safe_unique_id(16)
 
-                # For the null expectation (sets lower bound on nulls)
-                null_expectation = gx_expectations.ExpectColumnValuesToBeNull(
-                    windows=[
-                        Window(
-                            constraint_fn=ExpectationConstraintFunction.MEAN,
-                            parameter_name=f"{unique_id_null}_null_value_min",
-                            range=5,
-                            offset=Offset(
-                                positive=interpolated_offset, negative=interpolated_offset
-                            ),
-                            strict=False,
-                        )
-                    ],
-                    column=column_name,
-                    mostly={"$PARAMETER": f"{unique_id_null}_null_value_min"},
-                )
+                    interpolated_offset = self._compute_triangular_interpolation_offset(
+                        value=null_count, input_range=(0.0, float(row_count))
+                    )
+
+                    # For the null expectation (sets lower bound on nulls)
+                    null_expectation = gx_expectations.ExpectColumnValuesToBeNull(
+                        windows=[
+                            Window(
+                                constraint_fn=ExpectationConstraintFunction.MEAN,
+                                parameter_name=f"{unique_id_null}_null_value_min",
+                                range=5,
+                                offset=Offset(
+                                    positive=interpolated_offset, negative=interpolated_offset
+                                ),
+                                strict=False,
+                            )
+                        ],
+                        column=column_name,
+                        mostly={"$PARAMETER": f"{unique_id_null}_null_value_min"},
+                    )
 
                 # For the not-null expectation (sets upper bound on nulls by requiring not-nulls)
                 not_null_expectation = gx_expectations.ExpectColumnValuesToNotBeNull(
@@ -469,6 +504,23 @@ class GenerateDataQualityCheckExpectationsAction(
                 expectation_ids.append(not_null_expectation_id)
 
         return expectation_ids
+
+    def _get_columns_missing_completeness_coverage(
+        self,
+        column_null_values_metric: list[ColumnMetric[int]],
+        pre_existing_completeness_change_expectations: list[
+            dict[Any, Any]
+        ],  # list of ExpectationConfiguration dicts
+    ) -> set(ColumnMetric[int]):
+        try:
+            columns_with_completeness_coverage = {
+                expectation.get("kwargs").get("column")
+                for expectation in pre_existing_completeness_change_expectations
+            }
+        except TypeError as e:
+            raise InvalidExpectationConfigurationError(str(e)) from e
+        all_columns = {column.column for column in column_null_values_metric}
+        return all_columns.difference(columns_with_completeness_coverage)
 
     def _compute_triangular_interpolation_offset(
         self, value: float, input_range: tuple[float, float]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250616.0.dev0"
+version = "20250616.0"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250616.1.dev0"
+version = "20250617.0.dev0"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250616.0"
+version = "20250616.1.dev0"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250617.0.dev2"
+version = "20250617.0.dev3"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]


### PR DESCRIPTION
Only add completeness change Expectations to columns that are missing coverage. 

This behavior is behind the `expect_non_null_proportion_enabled` feature flag. 