### PR TITLE
Add `EventType` for static analysis of dynamic `Event`s

### DIFF
--- a/great_expectations_cloud/agent/__init__.py
+++ b/great_expectations_cloud/agent/__init__.py
@@ -2,5 +2,7 @@ from __future__ import annotations
 
 import great_expectations_cloud.agent.actions  # import actions to register them
 from great_expectations_cloud.agent.agent import GXAgent
+from great_expectations_cloud.agent.event_handler import register_event_action
+from great_expectations_cloud.agent.models import Event, EventType
 from great_expectations_cloud.agent.run import get_version, run_agent
 from great_expectations_cloud.agent.utils import triangular_interpolation

--- a/great_expectations_cloud/agent/actions/agent_action.py
+++ b/great_expectations_cloud/agent/actions/agent_action.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import datetime
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union
 from uuid import UUID
 
 from pydantic.v1 import BaseModel
 
-from great_expectations_cloud.agent.models import CreatedResource, Event
+from great_expectations_cloud.agent.models import (
+    AgentBaseExtraForbid,
+    AgentBaseExtraIgnore,
+    CreatedResource,
+)
 
 if TYPE_CHECKING:
     from great_expectations.data_context import CloudDataContext
@@ -23,10 +27,10 @@ class ActionResult(BaseModel):
     )
 
 
-_EventT = TypeVar("_EventT", bound=Event)
+_EventTypeT = TypeVar("_EventTypeT", bound=Union[AgentBaseExtraForbid, AgentBaseExtraIgnore])
 
 
-class AgentAction(Generic[_EventT]):
+class AgentAction(Generic[_EventTypeT]):
     def __init__(
         self, context: CloudDataContext, base_url: str, organization_id: UUID, auth_key: str
     ):
@@ -36,4 +40,4 @@ class AgentAction(Generic[_EventT]):
         self._auth_key = auth_key
 
     @abstractmethod
-    def run(self, event: _EventT, id: str) -> ActionResult: ...
+    def run(self, event: _EventTypeT, id: str) -> ActionResult: ...

--- a/great_expectations_cloud/agent/actions/agent_action.py
+++ b/great_expectations_cloud/agent/actions/agent_action.py
@@ -27,10 +27,10 @@ class ActionResult(BaseModel):
     )
 
 
-_EventTypeT = TypeVar("_EventTypeT", bound=Union[AgentBaseExtraForbid, AgentBaseExtraIgnore])
+_EventT = TypeVar("_EventT", bound=Union[AgentBaseExtraForbid, AgentBaseExtraIgnore])
 
 
-class AgentAction(Generic[_EventTypeT]):
+class AgentAction(Generic[_EventT]):
     def __init__(
         self, context: CloudDataContext, base_url: str, organization_id: UUID, auth_key: str
     ):
@@ -40,4 +40,4 @@ class AgentAction(Generic[_EventTypeT]):
         self._auth_key = auth_key
 
     @abstractmethod
-    def run(self, event: _EventTypeT, id: str) -> ActionResult: ...
+    def run(self, event: _EventT, id: str) -> ActionResult: ...

--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -16,6 +16,7 @@ from great_expectations_cloud.agent.actions.unknown import UnknownEventAction
 from great_expectations_cloud.agent.exceptions import GXAgentError
 from great_expectations_cloud.agent.models import (
     Event,
+    EventType,
     UnknownEvent,
 )
 
@@ -44,7 +45,7 @@ _EVENT_ACTION_MAP: dict[str, dict[str, type[AgentAction[Any]]]] = defaultdict(di
 
 
 def register_event_action(
-    version: str, event_type: type[Event], action_class: type[AgentAction[Any]]
+    version: str, event_type: EventType, action_class: type[AgentAction[Any]]
 ) -> None:
     """Register an event type to an action class."""
     if version in _EVENT_ACTION_MAP and event_type.__name__ in _EVENT_ACTION_MAP[version]:

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -144,6 +144,10 @@ class MissingEventSubclasses(RuntimeError):
         super().__init__("No valid Event subclasses found")
 
 
+# Type alias for any event class that can be used in the dynamic system
+EventType = type[Union[AgentBaseExtraForbid, AgentBaseExtraIgnore]]
+
+
 #
 # Dynamically build Event union from all subclasses of AgentBaseExtraForbid and AgentBaseExtraIgnore
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250627.0.dev0"
+version = "20250701.0.dev0"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -189,10 +189,10 @@ class DummyEvent(EventBase):
     organization_id: UUID | None = None
 
 
-class DummyAction(AgentAction[Any]):
+class DummyAction(AgentAction[DummyEvent]):
     # Dummy event is used for testing only
     @override
-    def run(self, event: Event, id: str) -> ActionResult:
+    def run(self, event: DummyEvent, id: str) -> ActionResult:
         return ActionResult(id=id, type="DummyAction", created_resources=[])
 
 

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -6,6 +6,7 @@ import uuid
 from collections import deque
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
+from uuid import UUID
 
 import pytest
 from great_expectations import (
@@ -185,6 +186,7 @@ def data_context_config() -> DataContextConfigTD:
 
 class DummyEvent(EventBase):
     type: Literal["event_name.received"] = "event_name.received"
+    organization_id: UUID | None = None
 
 
 class DummyAction(AgentAction[Any]):

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -193,7 +193,7 @@ class DummyAction(AgentAction[Any]):
     # Dummy event is used for testing only
     @override
     def run(self, event: Event, id: str) -> ActionResult:
-        return ActionResult(id=id, type="DummyAction", created_resources=[], job_duration=None)
+        return ActionResult(id=id, type="DummyAction", created_resources=[])
 
 
 register_event_action("1", DummyEvent, DummyAction)

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -191,7 +191,7 @@ class DummyAction(AgentAction[Any]):
     # Dummy event is used for testing only
     @override
     def run(self, event: Event, id: str) -> ActionResult:
-        return ActionResult(id=id, type="DummyAction", created_resources=[])
+        return ActionResult(id=id, type="DummyAction", created_resources=[], job_duration=None)
 
 
-register_event_action("1", DummyEvent, DummyAction)  # type: ignore[arg-type]
+register_event_action("1", DummyEvent, DummyAction)

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -213,7 +213,12 @@ class TestEventHandler:
         handler = EventHandler(context=mock_context)
 
         with pytest.raises(NoVersionImplementationError):
-            handler.get_event_action(DummyEvent, base_url="", auth_key="", organization_id=uuid4())  # type: ignore[arg-type]  # Dummy event only used in testing
+            handler.get_event_action(
+                DummyEvent(),  # type: ignore[arg-type]  # Dummy event only used in testing
+                base_url="",
+                auth_key="",
+                organization_id=uuid4(),
+            )
 
 
 class TestEventHandlerRegistry:
@@ -226,23 +231,23 @@ class TestEventHandlerRegistry:
     )
     def test_register_event_action(self, mocker: MockerFixture, version: str):
         mocker.patch.dict(_EVENT_ACTION_MAP, {}, clear=True)
-        register_event_action(version, DummyEvent, DummyAction)  # type: ignore[arg-type]
+        register_event_action(version, DummyEvent, DummyAction)
         assert _EVENT_ACTION_MAP[version][DummyEvent.__name__] == DummyAction
 
     def test_register_event_action_already_registered(self, mocker: MockerFixture):
         mocker.patch.dict(_EVENT_ACTION_MAP, {}, clear=True)
-        register_event_action("0", DummyEvent, DummyAction)  # type: ignore[arg-type]
+        register_event_action("0", DummyEvent, DummyAction)
         with pytest.raises(EventAlreadyRegisteredError):
-            register_event_action("0", DummyEvent, DummyAction)  # type: ignore[arg-type]
+            register_event_action("0", DummyEvent, DummyAction)
 
     def test_event_handler_gets_correct_event_action(self, mocker: MockerFixture, mock_context):
         mocker.patch.dict(_EVENT_ACTION_MAP, {}, clear=True)
         DummyEvent.organization_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
-        register_event_action("1", DummyEvent, DummyAction)  # type: ignore[arg-type]
+        register_event_action("1", DummyEvent, DummyAction)
         handler = EventHandler(context=mock_context)
         assert isinstance(
             handler.get_event_action(
-                DummyEvent,  # type: ignore[arg-type]  # Dummy event only used in testing
+                DummyEvent(),  # type: ignore[arg-type]  # Dummy event only used in testing
                 base_url="",
                 auth_key="",
                 organization_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -212,12 +212,13 @@ class TestEventHandler:
 
         handler = EventHandler(context=mock_context)
 
+        test_org_id = uuid4()
         with pytest.raises(NoVersionImplementationError):
             handler.get_event_action(
-                DummyEvent(),  # type: ignore[arg-type]  # Dummy event only used in testing
+                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing
                 base_url="",
                 auth_key="",
-                organization_id=uuid4(),
+                organization_id=test_org_id,
             )
 
 
@@ -242,15 +243,15 @@ class TestEventHandlerRegistry:
 
     def test_event_handler_gets_correct_event_action(self, mocker: MockerFixture, mock_context):
         mocker.patch.dict(_EVENT_ACTION_MAP, {}, clear=True)
-        DummyEvent.organization_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
+        test_org_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
         register_event_action("1", DummyEvent, DummyAction)
         handler = EventHandler(context=mock_context)
         assert isinstance(
             handler.get_event_action(
-                DummyEvent(),  # type: ignore[arg-type]  # Dummy event only used in testing
+                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing
                 base_url="",
                 auth_key="",
-                organization_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),
+                organization_id=test_org_id,
             ),
             DummyAction,
         )

--- a/tests/agent/test_event_handler.py
+++ b/tests/agent/test_event_handler.py
@@ -215,7 +215,7 @@ class TestEventHandler:
         test_org_id = uuid4()
         with pytest.raises(NoVersionImplementationError):
             handler.get_event_action(
-                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing
+                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing, get_event_action is not used by external systems, so we can keep the type narrowed to known Events
                 base_url="",
                 auth_key="",
                 organization_id=test_org_id,
@@ -248,7 +248,7 @@ class TestEventHandlerRegistry:
         handler = EventHandler(context=mock_context)
         assert isinstance(
             handler.get_event_action(
-                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing
+                DummyEvent(organization_id=test_org_id),  # type: ignore[arg-type]  # Dummy event only used in testing, get_event_action is not used by external systems, so we can keep the type narrowed to known Events
                 base_url="",
                 auth_key="",
                 organization_id=test_org_id,


### PR DESCRIPTION
- Make `type[Event]` more broad by introducing `EventType`, which can be used during static analysis
- This enables us to define events in external systems without needing type ignores