### PR TITLE
use latest Event union state

### DIFF
--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -17,7 +17,8 @@ from great_expectations_cloud.agent.exceptions import GXAgentError
 from great_expectations_cloud.agent.models import (
     Event,
     EventType,
-    UnknownEvent, get_event_union,
+    UnknownEvent,
+    get_event_union,
 )
 
 if TYPE_CHECKING:

--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -17,7 +17,7 @@ from great_expectations_cloud.agent.exceptions import GXAgentError
 from great_expectations_cloud.agent.models import (
     Event,
     EventType,
-    UnknownEvent,
+    UnknownEvent, get_event_union,
 )
 
 if TYPE_CHECKING:
@@ -103,8 +103,9 @@ class EventHandler:
 
     @classmethod
     def parse_event_from(cls, msg_body: bytes) -> Event:
+        event_union = get_event_union()
         try:
-            event: Event = pydantic_v1.parse_raw_as(Event, msg_body)  # type: ignore[arg-type] # FIXME
+            event: Event = pydantic_v1.parse_raw_as(event_union, msg_body)  # type: ignore[arg-type] # FIXME
         except (pydantic_v1.ValidationError, JSONDecodeError):
             # Log as bytes
             LOGGER.exception("Unable to parse event type", extra={"msg_body": f"{msg_body!r}"})

--- a/great_expectations_cloud/agent/event_handler.py
+++ b/great_expectations_cloud/agent/event_handler.py
@@ -106,7 +106,7 @@ class EventHandler:
     def parse_event_from(cls, msg_body: bytes) -> Event:
         event_union = get_event_union()
         try:
-            event: Event = pydantic_v1.parse_raw_as(event_union, msg_body)  # type: ignore[arg-type] # FIXME
+            event: Event = pydantic_v1.parse_raw_as(event_union, msg_body)
         except (pydantic_v1.ValidationError, JSONDecodeError):
             # Log as bytes
             LOGGER.exception("Unable to parse event type", extra={"msg_body": f"{msg_body!r}"})

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -200,13 +200,22 @@ else:
 
 
 def reload_event_union() -> None:
-    global Event
+    """Rebuild the Event union dynamically.
+
+    Call this method after subclassing one of the EventBase models in order
+    to make it available in the Event union."""
+    global Event  # noqa: PLW0603
     reloaded_event_classes = _build_event_union()
     Event = Annotated[Union[reloaded_event_classes], Field(discriminator="type")]
 
 
 def get_event_union() -> Event:
-    global Event
+    """Canonical way to access the Event union for non-typing use cases.
+
+    The Event union can be dynamically extended when the Agent codebase is extended.
+    Those subclasses will be defined after the Event model is defined in this module.
+    This function allows callers to access the full union that includes those subclasses.
+    """
     return Event
 
 

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -199,6 +199,17 @@ else:
     Event = Annotated[Union[_event_classes], Field(discriminator="type")]
 
 
+def reload_event_union() -> None:
+    global Event
+    reloaded_event_classes = _build_event_union()
+    Event = Annotated[Union[reloaded_event_classes], Field(discriminator="type")]
+
+
+def get_event_union() -> Event:
+    global Event
+    return Event
+
+
 class CreatedResource(AgentBaseExtraForbid):
     resource_id: str
     type: str

--- a/great_expectations_cloud/agent/models.py
+++ b/great_expectations_cloud/agent/models.py
@@ -206,15 +206,30 @@ def reload_event_union() -> None:
     to make it available in the Event union."""
     global Event  # noqa: PLW0603
     reloaded_event_classes = _build_event_union()
-    Event = Annotated[Union[reloaded_event_classes], Field(discriminator="type")]
+    Event = Annotated[Union[reloaded_event_classes], Field(discriminator="type")]  # type: ignore[valid-type]
 
 
-def get_event_union() -> Event:
+def get_event_union() -> Any:
     """Canonical way to access the Event union for non-typing use cases.
 
     The Event union can be dynamically extended when the Agent codebase is extended.
     Those subclasses will be defined after the Event model is defined in this module.
     This function allows callers to access the full union that includes those subclasses.
+
+    Returns:
+        A dynamically constructed discriminated Union type suitable for pydantic parsing.
+
+    Type Bounds:
+        All members of the returned Union are subclasses of either:
+        - AgentBaseExtraForbid: Event classes with strict field validation
+        - AgentBaseExtraIgnore: Event classes that ignore extra fields
+
+        The actual return type is equivalent to:
+        Annotated[Union[<all_event_subclasses>], Field(discriminator="type")]
+
+        This cannot be statically typed due to the dynamic discovery of subclasses,
+        so we use Any. At runtime, this represents a properly typed
+        discriminated union of concrete event model classes.
     """
     return Event
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "great_expectations_cloud"
-version = "20250708.0.dev0"
+version = "20250709.0.dev0"
 
 description = "Great Expectations Cloud"
 authors = ["The Great Expectations Team <team@greatexpectations.io>"]


### PR DESCRIPTION
This PR ensures that when we validate an Event against the union of available pydantic models, we're including any subclasses which may be defined by callers.