### PR TITLE
use tini for init process in Dockerfile

### DIFF
--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -27,4 +27,4 @@ jobs:
           tags: local_agent
 
       - name: Smoke test image
-        run: docker run --rm local_agent --version
+        run: docker run --rm local_agent poetry run gx-agent --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install --no-install-recommends -y \
       python3-dev=3.13.5-1 gcc=4:14.2.0-1 \
-      curl=8.14.1-2 gnupg=2.4.7-21 ca-certificates=20250419 unixodbc=2.3.12-2 && \
+      curl=8.14.1-2 gnupg=2.4.7-21 ca-certificates=20250419 unixodbc=2.3.12-2 \
+      tini=0.19.0-3+b3 && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg && \
     echo "deb [arch=amd64,arm64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
@@ -71,4 +72,5 @@ ENV GX_ANALYTICS_ENABLED=false
 # Disable progress bars
 ENV ENABLE_PROGRESS_BARS=false
 
-ENTRYPOINT ["poetry", "run", "gx-agent"]
+ENTRYPOINT ["tini", "--"]
+CMD ["poetry", "run", "gx-agent"]


### PR DESCRIPTION
In certain containerized deployments, invoking gx-agent directly will cause it to assume PID 1, which can cause conflicts when receiving `kill` events without properly defined signal handlers. Using `tini` as the standard invocation introduces a small init layer so that the underlying CMD for the container can exit without hanging.